### PR TITLE
The Populate Release script now supports branch names and commit hashes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ bash script/populate_release.sh R1-2024-csp-9 quesnelia
 _Make sure to manually delete any already downloaded JSON files to avoid accidentally including the wrong dependencies for some flower release when executing this script for multiple flower releases._
 
 
-### Populate via Branches and Commit Hashes
+#### Populate via Branches and Commit Hashes
 
 The population can be done via a branch name or a commit hash rather than only a tag name.
 

--- a/README.md
+++ b/README.md
@@ -54,5 +54,5 @@ POPULATE_RELEASE_REPOSITORY_PART="heads" bash script/populate_release.sh snapsho
 
 Example commit hash usage:
 ```shell
-POPULATE_RELEASE_REPOSITORY_PART="heads" bash script/populate_release.sh fe7223e040d5d024f3f4961a3bc324d99a6fe7f5 aggies
+POPULATE_RELEASE_REPOSITORY_PART="" bash script/populate_release.sh fe7223e040d5d024f3f4961a3bc324d99a6fe7f5 aggies
 ```

--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ The **MDR** _GitHub Pages_ may be found at [https://tamulib.github.io/folio-modu
 
 The Module Descriptors for each release are found within the `release/` subdirectory.
 
+
 ## Scripts
 
 This repository provides additional scripts that may help facilitate the generation of the Module Descriptors.
+
 
 ### Populate Release
 
@@ -30,8 +32,27 @@ The flower release name in relation to its release date designation (which maps 
 View the documentation within the `populate_release.sh` script for further details on how to operate this script.
 
 Example usage:
-```sh
+```shell
 bash script/populate_release.sh R1-2024-csp-9 quesnelia
 ```
 
 _Make sure to manually delete any already downloaded JSON files to avoid accidentally including the wrong dependencies for some flower release when executing this script for multiple flower releases._
+
+
+### Populate via Branches and Commit Hashes
+
+The population can be done via a branch name or a commit hash rather than only a tag name.
+
+The `POPULATE_RELEASE_REPOSITORY_PART` environment variable should be used to specify this.
+The value must be set to `heads` to use a branch name.
+The value must be set to an empty string to use a specific commit hash instead of either a tag name or a branch name.
+
+Example branch name usage:
+```shell
+POPULATE_RELEASE_REPOSITORY_PART="heads" bash script/populate_release.sh snapshot snapshot
+```
+
+Example commit hash usage:
+```shell
+POPULATE_RELEASE_REPOSITORY_PART="heads" bash script/populate_release.sh fe7223e040d5d024f3f4961a3bc324d99a6fe7f5 aggies
+```

--- a/script/populate_release.sh
+++ b/script/populate_release.sh
@@ -13,27 +13,37 @@
 #    2) (optional) The Flower release name, such as "quesnelia".
 #
 #  Environment Variables:
-#    POPULATE_RELEASE_DESTINATION:    Destination parent directory.
-#    POPULATE_RELEASE_FILE:           The name of the install.json file as it is stored locally after GET fetching.
-#    POPULATE_RELEASE_FILE_REUSE:     Enable re-using existing install.json file without GET fetching, any non-empty string is enables this.
-#    POPULATE_RELEASE_REGISTRY:       The URL to GET the module descriptor from for some specific module version.
-#    POPULATE_RELEASE_RELEASE:        The GitHub release tag; If specified, then the associated parameter is ignored.
-#    POPULATE_RELEASE_RELEASE_DEBUG:  Enable debug verbosity, any non-empty string is enables this.
-#    POPULATE_RELEASE_RELEASE_FLOWER: The Flower release name; If specified, then the associated parameter is ignored.
-#    POPULATE_RELEASE_REPOSITORY:     The GitHub repository URL to fetch from, down to the tags (but without the specific tag name).
+#    POPULATE_RELEASE_DESTINATION:     Destination parent directory.
+#    POPULATE_RELEASE_FILE:            The name of the install.json file as it is stored locally after GET fetching.
+#    POPULATE_RELEASE_FILE_REUSE:      Enable re-using existing install.json file without GET fetching, any non-empty string is enables this.
+#    POPULATE_RELEASE_REGISTRY:        The URL to GET the module descriptor from for some specific module version.
+#    POPULATE_RELEASE_RELEASE:         The GitHub release tag; If specified, then the associated parameter is ignored.
+#    POPULATE_RELEASE_RELEASE_DEBUG:   Enable debug verbosity, any non-empty string is enables this.
+#    POPULATE_RELEASE_RELEASE_FLOWER:  The Flower release name; If specified, then the associated parameter is ignored.
+#    POPULATE_RELEASE_REPOSITORY:      The raw GitHub repository URL to fetch from (but without the URL parts after the repository name).
+#    POPULATE_RELEASE_REPOSITORY_PART: The part of the Github repository URL specifying the tag, branch, or hash (but without either the specific tag/branch name or the file path).
 #
-# Note: It might be possible to swap out POPULATE_RELEASE_REPOSITORY and POPULATE_RELEASE_RELEASE with a branch name rather than a tag name.
+# The following POPULATE_RELEASE_REPOSITORY_PART are known to work in GitHub:
+#   - 'tags':  Designate that this uses a tag name that is specified via the POPULATE_RELEASE_RELEASE (the default).
+#   - 'heads': Designate that this uses a branch name that is specified via the POPULATE_RELEASE_RELEASE.
+#   - '':      Leave empty for when using a commit hash, in which case the POPULATE_RELEASE_RELEASE must be a valid hash.
+#
+# The POPULATE_RELEASE_RELEASE_DEBUG may be specifically set to "curl" to include printing the curl commands.
+# The POPULATE_RELEASE_RELEASE_DEBUG may be specifically set to "curl_only" to only print the curl commands, disabling all other debugging (does not pass -v to curl).
+# Otherwise, any non-empty value will result in debug printing without the curl command.
 #
 
 main() {
   local debug=
+  local debug_curl=
   local registry="https://folio-registry.dev.folio.org/_/proxy/modules/"
   local destination="release/"
   local file="install.json"
   local i=
+  local part="tags"
   local release=$(echo ${1} | sed -e 's|/||g')
   local release_flower=$(echo ${2} | sed -e 's|/||g')
-  local repository="https://raw.githubusercontent.com/folio-org/platform-complete/refs/tags/"
+  local repository="https://raw.githubusercontent.com/folio-org/platform-complete/"
   local releases=
   local source=
 
@@ -45,33 +55,49 @@ main() {
 
   if [[ ${POPULATE_RELEASE_RELEASE_DEBUG} != "" ]] ; then
     debug="-v"
+    debug_curl=""
+
+    if [[ ${POPULATE_RELEASE_RELEASE_DEBUG} == "curl" ]] ; then
+      debug_curl="y"
+    elif [[ ${POPULATE_RELEASE_RELEASE_DEBUG} == "curl_only" ]] ; then
+      debug=""
+      debug_curl="y"
+    fi
   fi
 
-  if [[ ${POPULATE_RELEASE_DESTINATION} != "" ]] ; then
+  if [[ -v POPULATE_RELEASE_DESTINATION ]] ; then
     destination=$(echo ${POPULATE_RELEASE_DESTINATION} | sed -e 's|/*$|/|g')
   fi
 
-  if [[ ${POPULATE_RELEASE_FILE} != "" ]] ; then
+  if [[ -v POPULATE_RELEASE_FILE ]] ; then
     file=$(echo ${POPULATE_RELEASE_FILE} | sed -e 's|/*$||')
   fi
 
-  if [[ ${POPULATE_RELEASE_REGISTRY} != "" ]] ; then
+  if [[ -v POPULATE_RELEASE_REGISTRY ]] ; then
     registry=$(echo ${POPULATE_RELEASE_REGISTRY} | sed -e 's|/*$|/|g')
   fi
 
-  if [[ ${POPULATE_RELEASE_RELEASE} != "" ]] ; then
+  if [[ -v POPULATE_RELEASE_RELEASE ]] ; then
     release=$(echo ${POPULATE_RELEASE_RELEASE} | sed -e 's|/||g')
   fi
 
-  if [[ ${POPULATE_RELEASE_RELEASE_FLOWER} != "" ]] ; then
+  if [[ -v POPULATE_RELEASE_RELEASE_FLOWER ]] ; then
     release_flower=$(echo ${POPULATE_RELEASE_RELEASE_FLOWER} | sed -e 's|/||g')
   fi
 
-  if [[ ${POPULATE_RELEASE_REPOSITORY} != "" ]] ; then
+  if [[ -v POPULATE_RELEASE_REPOSITORY ]] ; then
     repository=$(echo ${POPULATE_RELEASE_REPOSITORY} | sed -e 's|/*$|/|g')
   fi
 
-  source="$(echo ${repository} | sed -e 's|/*$|/|')${release}/install.json"
+  if [[ -v POPULATE_RELEASE_REPOSITORY_PART ]] ; then
+    part=${POPULATE_RELEASE_REPOSITORY_PART}
+  fi
+
+  if [[ ${part} != "" ]] ; then
+    part="refs/$(echo ${part} | sed -e 's|/*$|/|g')"
+  fi
+
+  source="$(echo ${repository} | sed -e 's|/*$|/|')${part}${release}/install.json"
 
   if [[ ${POPULATE_RELEASE_FILE_REUSE} != "" ]] ; then
     if [[ ! -f ${file} ]] ; then
@@ -94,6 +120,11 @@ main() {
 
         return ${result}
       fi
+    fi
+
+    if [[ ${debug_curl} != "" ]] ; then
+      echo "${p_d}Executing Package Curl: curl -w '\n' ${debug} ${source} -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'cache-control: no-cache' -o ${file} ."
+      echo
     fi
 
     curl -w '\n' ${debug} ${source} -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'cache-control: no-cache' -o ${file}
@@ -138,6 +169,11 @@ main() {
         echo
       else
         echo "Curl requesting Module Descriptor: ${i}."
+      fi
+
+      if [[ ${debug_curl} != "" ]] ; then
+        echo "${p_d}Executing Descriptor Curl: curl -w '\n' ${debug} ${source} -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'cache-control: no-cache' -o ${file} ."
+        echo
       fi
 
       curl -w '\n' ${debug} ${registry}${i} -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'cache-control: no-cache' -o ${destination}${release_flower}/${i}


### PR DESCRIPTION
Update the documentation accordingly.

Add additional debug modes to make it easier to look at some actions rather than others. The `curl` and `curl_only` debug modes allow for displaying the actual curl command being executed.