### PR TITLE
Add Synchronize workflow and script, updating the Gh pages and Populate Release script.

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - snapshot
 
+  workflow_dispatch:
+
 jobs:
   pages-directory-listing:
     runs-on: ubuntu-latest

--- a/.github/workflows/sync_snapshot.yml
+++ b/.github/workflows/sync_snapshot.yml
@@ -1,0 +1,104 @@
+name: sync_snapshot
+run-name: Synchronize Snapshot by @${{ github.actor }}
+
+on:
+  schedule:
+    - cron: '0 0 */1 * *'
+
+  workflow_dispatch:
+    inputs:
+      prssDebug:
+        description: 'Debug Mode'
+        type: choice
+        required: false
+        default: ''
+        options:
+          yes
+          curl
+          curl_only
+          curl_git
+          git
+          git_only
+      prDestination:
+        description: 'Populate Release Destination'
+        type: string
+        required: false
+        default: ''
+      prFile:
+        description: 'Populate Release File'
+        type: string
+        required: false
+        default: ''
+      prFlower:
+        description: 'Populate Release Flower'
+        type: string
+        required: true
+        default: 'snapshot
+      prRepository:
+        description: 'Populate Release Repository'
+        type: string
+        required: false
+        default: ''
+      prRepositoryPart:
+        description: 'Populate Release Repository Part'
+        type: string
+        required: true
+        default: 'heads'
+      prRegistry:
+        description: Populate Release Registry
+        type: string
+        required: false
+        default: ''
+      prTarget:
+        description: 'Populate Release Target'
+        type: string
+        required: true
+        default: 'snapshot'
+      ssMessage:
+        description: 'Synchronize Snapshot Message'
+        type: string
+        required: false
+        default: ''
+
+jobs:
+  run-script:
+    runs-on: ubuntu-latest
+    name: Update Registry
+    permissions:
+      contents: write # To push the changes.
+    steps:
+      - name: Checkout Scripts
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          path: scripts
+          sparse-checkout: |
+            script/populate_release.sh
+            script/sync_snapshot.sh
+      - name: Checkout Registry
+        uses: actions/checkout@v4
+        with:
+          ref: snapshot
+          path: snapshot
+      - name: Populate Snapshot
+        working-directory: ${GITHUB_WORKSPACE}/snapshot
+        env:
+          POPULATE_RELEASE_DEBUG: ${{ inputs.prssDebug }}
+          POPULATE_RELEASE_DESTINATION:  ${{ inputs.prDestination }}
+          POPULATE_RELEASE_FILE: ${{ inputs.prFile }}
+          POPULATE_RELEASE_FLOWER: ${{ inputs.prFlower }}
+          POPULATE_RELEASE_REPOSITORY: ${{ inputs.prRepository }}
+          POPULATE_RELEASE_REPOSITORY_PART: ${{ inputs.prRepositoryPart }}
+          POPULATE_RELEASE_REGISTRY: ${{ inputs.prRegistry }}
+          POPULATE_RELEASE_TARGET: ${{ inputs.prTarget }}ssMessage
+        run: |
+          bash ${GITHUB_WORKSPACE}/scripts/script/populate_release.sh
+      - name: Synchronize Snapshot
+        working-directory: ${GITHUB_WORKSPACE}/snapshot
+        env:
+          SYNC_SNAPSHOT_DEBUG: ${{ inputs.prssDebug }}
+          SYNC_SNAPSHOT_MESSAGE: ${{ inputs.ssMessage }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          bash ${GITHUB_WORKSPACE}/scripts/script/sync_snapshot.sh

--- a/.github/workflows/sync_snapshot.yml
+++ b/.github/workflows/sync_snapshot.yml
@@ -6,59 +6,6 @@ on:
     - cron: '0 0 */1 * *'
 
   workflow_dispatch:
-    inputs:
-      prssDebug:
-        description: 'Debug Mode'
-        type: choice
-        required: false
-        default: ''
-        options:
-          yes
-          curl
-          curl_only
-          curl_git
-          git
-          git_only
-      prDestination:
-        description: 'Populate Release Destination'
-        type: string
-        required: false
-        default: ''
-      prFile:
-        description: 'Populate Release File'
-        type: string
-        required: false
-        default: ''
-      prFlower:
-        description: 'Populate Release Flower'
-        type: string
-        required: true
-        default: 'snapshot'
-      prRepository:
-        description: 'Populate Release Repository'
-        type: string
-        required: false
-        default: ''
-      prRepositoryPart:
-        description: 'Populate Release Repository Part'
-        type: string
-        required: true
-        default: 'heads'
-      prRegistry:
-        description: Populate Release Registry
-        type: string
-        required: false
-        default: ''
-      prTarget:
-        description: 'Populate Release Target'
-        type: string
-        required: true
-        default: 'snapshot'
-      ssMessage:
-        description: 'Synchronize Snapshot Message'
-        type: string
-        required: false
-        default: ''
 
 jobs:
   run-script:
@@ -67,6 +14,10 @@ jobs:
     permissions:
       contents: write # To push the changes.
     steps:
+      - name: Create Working Directories
+        run: |
+          mkdir scripts
+          mkdir populate
       - name: Checkout Scripts
         uses: actions/checkout@v4
         with:
@@ -79,26 +30,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: snapshot
-          path: snapshot
+          path: populate
       - name: Populate Snapshot
-        working-directory: ${GITHUB_WORKSPACE}/snapshot
-        env:
-          POPULATE_RELEASE_DEBUG: ${{ inputs.prssDebug }}
-          POPULATE_RELEASE_DESTINATION:  ${{ inputs.prDestination }}
-          POPULATE_RELEASE_FILE: ${{ inputs.prFile }}
-          POPULATE_RELEASE_FLOWER: ${{ inputs.prFlower }}
-          POPULATE_RELEASE_REPOSITORY: ${{ inputs.prRepository }}
-          POPULATE_RELEASE_REPOSITORY_PART: ${{ inputs.prRepositoryPart }}
-          POPULATE_RELEASE_REGISTRY: ${{ inputs.prRegistry }}
-          POPULATE_RELEASE_TARGET: ${{ inputs.prTarget }}ssMessage
+        working-directory: populate
         run: |
-          bash ${GITHUB_WORKSPACE}/scripts/script/populate_release.sh
+          bash ../scripts/script/populate_release.sh
       - name: Synchronize Snapshot
-        working-directory: ${GITHUB_WORKSPACE}/snapshot
-        env:
-          SYNC_SNAPSHOT_DEBUG: ${{ inputs.prssDebug }}
-          SYNC_SNAPSHOT_MESSAGE: ${{ inputs.ssMessage }}
+        working-directory: populate
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          bash ${GITHUB_WORKSPACE}/scripts/script/sync_snapshot.sh
+          bash ../scripts/script/sync_snapshot.sh

--- a/.github/workflows/sync_snapshot.yml
+++ b/.github/workflows/sync_snapshot.yml
@@ -33,7 +33,7 @@ on:
         description: 'Populate Release Flower'
         type: string
         required: true
-        default: 'snapshot
+        default: 'snapshot'
       prRepository:
         description: 'Populate Release Repository'
         type: string

--- a/script/populate_release.sh
+++ b/script/populate_release.sh
@@ -9,27 +9,27 @@
 #   - sed
 #
 #  Parameters:
-#    1) (optional) The GitHub release tag, such as "R1-2024-csp-9" (If not needed but (2) is, then set this to an empty string).
-#    2) (optional) The Flower release name, such as "quesnelia".
+#    1) (optional) The GitHub release tag (target), such as "R1-2024-csp-9" (If not needed but (2) is, then set this to an empty string).
+#    2) (optional) The Flower release name, such as "quesnelia" or "snapshot", used to create the destination directory.
 #
 #  Environment Variables:
+#    POPULATE_RELEASE_DEBUG:           Enable debug verbosity, any non-empty string is enables this.
 #    POPULATE_RELEASE_DESTINATION:     Destination parent directory.
 #    POPULATE_RELEASE_FILE:            The name of the install.json file as it is stored locally after GET fetching.
 #    POPULATE_RELEASE_FILE_REUSE:      Enable re-using existing install.json file without GET fetching, any non-empty string is enables this.
+#    POPULATE_RELEASE_FLOWER:          The Flower release name; If specified, then the associated parameter is ignored.
 #    POPULATE_RELEASE_REGISTRY:        The URL to GET the module descriptor from for some specific module version.
-#    POPULATE_RELEASE_RELEASE:         The GitHub release tag; If specified, then the associated parameter is ignored.
-#    POPULATE_RELEASE_RELEASE_DEBUG:   Enable debug verbosity, any non-empty string is enables this.
-#    POPULATE_RELEASE_RELEASE_FLOWER:  The Flower release name; If specified, then the associated parameter is ignored.
 #    POPULATE_RELEASE_REPOSITORY:      The raw GitHub repository URL to fetch from (but without the URL parts after the repository name).
 #    POPULATE_RELEASE_REPOSITORY_PART: The part of the Github repository URL specifying the tag, branch, or hash (but without either the specific tag/branch name or the file path).
+#    POPULATE_RELEASE_TARGET:          The GitHub release tag; If specified, then the associated parameter is ignored.
 #
 # The following POPULATE_RELEASE_REPOSITORY_PART are known to work in GitHub:
-#   - 'tags':  Designate that this uses a tag name that is specified via the POPULATE_RELEASE_RELEASE (the default).
-#   - 'heads': Designate that this uses a branch name that is specified via the POPULATE_RELEASE_RELEASE.
-#   - '':      Leave empty for when using a commit hash, in which case the POPULATE_RELEASE_RELEASE must be a valid hash.
+#   - 'tags':  Designate that this uses a tag name that is specified via the POPULATE_RELEASE_TARGET.
+#   - 'heads': Designate that this uses a branch name that is specified via the POPULATE_RELEASE_TARGET (the default).
+#   - '':      Set to an empty string for when using a commit hash, in which case the POPULATE_RELEASE_TARGET must be a valid hash.
 #
-# The POPULATE_RELEASE_RELEASE_DEBUG may be specifically set to "curl" to include printing the curl commands.
-# The POPULATE_RELEASE_RELEASE_DEBUG may be specifically set to "curl_only" to only print the curl commands, disabling all other debugging (does not pass -v to curl).
+# The POPULATE_RELEASE_DEBUG may be specifically set to "curl" to include printing the curl commands.
+# The POPULATE_RELEASE_DEBUG may be specifically set to "curl_only" to only print the curl commands, disabling all other debugging (does not pass -v to curl).
 # Otherwise, any non-empty value will result in debug printing without the curl command.
 #
 
@@ -40,9 +40,9 @@ main() {
   local destination="release/"
   local file="install.json"
   local i=
-  local part="tags"
-  local release=$(echo ${1} | sed -e 's|/||g')
-  local release_flower=$(echo ${2} | sed -e 's|/||g')
+  local part="heads"
+  local target="snapshot"
+  local flower="snapshot"
   local repository="https://raw.githubusercontent.com/folio-org/platform-complete/"
   local releases=
   local source=
@@ -53,42 +53,55 @@ main() {
 
   local -i result=0
 
-  if [[ ${POPULATE_RELEASE_RELEASE_DEBUG} != "" ]] ; then
+  if [[ ${1} != "" ]] ; then
+    target=$(echo ${1} | sed -e 's|/||g')
+  fi
+
+  if [[ ${2} != "" ]] ; then
+    flower=$(echo ${2} | sed -e 's|/||g')
+  fi
+
+  if [[ ${POPULATE_RELEASE_DEBUG} != "" ]] ; then
     debug="-v"
     debug_curl=""
 
-    if [[ ${POPULATE_RELEASE_RELEASE_DEBUG} == "curl" ]] ; then
+    if [[ ${POPULATE_RELEASE_DEBUG} == "curl" ]] ; then
       debug_curl="y"
-    elif [[ ${POPULATE_RELEASE_RELEASE_DEBUG} == "curl_only" ]] ; then
+    elif [[ ${POPULATE_RELEASE_DEBUG} == "curl_only" ]] ; then
       debug=""
+      debug_curl="y"
+    elif [[ $(echo ${POPULATE_RELEASE_DEBUG} | grep -sho "_only") != "" ]] ; then
+      debug=""
+    elif [[ $(echo ${POPULATE_RELEASE_DEBUG} | grep -sho "\<curl\>") != "" ]] ; then
       debug_curl="y"
     fi
   fi
 
-  if [[ -v POPULATE_RELEASE_DESTINATION ]] ; then
+  if [[ ${POPULATE_RELEASE_DESTINATION} != "" ]] ; then
     destination=$(echo ${POPULATE_RELEASE_DESTINATION} | sed -e 's|/*$|/|g')
   fi
 
-  if [[ -v POPULATE_RELEASE_FILE ]] ; then
+  if [[ ${POPULATE_RELEASE_FILE} != "" ]] ; then
     file=$(echo ${POPULATE_RELEASE_FILE} | sed -e 's|/*$||')
   fi
 
-  if [[ -v POPULATE_RELEASE_REGISTRY ]] ; then
+  if [[ ${POPULATE_RELEASE_REGISTRY} != "" ]] ; then
     registry=$(echo ${POPULATE_RELEASE_REGISTRY} | sed -e 's|/*$|/|g')
   fi
 
-  if [[ -v POPULATE_RELEASE_RELEASE ]] ; then
-    release=$(echo ${POPULATE_RELEASE_RELEASE} | sed -e 's|/||g')
+  if [[ ${POPULATE_RELEASE_TARGET} != "" ]] ; then
+    target=$(echo ${POPULATE_RELEASE_TARGET} | sed -e 's|/||g')
   fi
 
-  if [[ -v POPULATE_RELEASE_RELEASE_FLOWER ]] ; then
-    release_flower=$(echo ${POPULATE_RELEASE_RELEASE_FLOWER} | sed -e 's|/||g')
+  if [[ ${POPULATE_RELEASE_FLOWER} != "" ]] ; then
+    flower=$(echo ${POPULATE_RELEASE_FLOWER} | sed -e 's|/||g')
   fi
 
-  if [[ -v POPULATE_RELEASE_REPOSITORY ]] ; then
+  if [[ ${POPULATE_RELEASE_REPOSITORY} != "" ]] ; then
     repository=$(echo ${POPULATE_RELEASE_REPOSITORY} | sed -e 's|/*$|/|g')
   fi
 
+  # May be empty, so use "-v" test rather than != "".
   if [[ -v POPULATE_RELEASE_REPOSITORY_PART ]] ; then
     part=${POPULATE_RELEASE_REPOSITORY_PART}
   fi
@@ -97,7 +110,7 @@ main() {
     part="refs/$(echo ${part} | sed -e 's|/*$|/|g')"
   fi
 
-  source="$(echo ${repository} | sed -e 's|/*$|/|')${part}${release}/install.json"
+  source="$(echo ${repository} | sed -e 's|/*$|/|')${part}${target}/${file}"
 
   if [[ ${POPULATE_RELEASE_FILE_REUSE} != "" ]] ; then
     if [[ ! -f ${file} ]] ; then
@@ -138,26 +151,28 @@ main() {
   fi
 
   if [[ -f ${file} ]] ; then
-    releases=$(grep -shnr '"id" : "' install.json | sed -e 's|^.*"id" : "||g' -e 's|",$||g')
+    releases=$(grep -shr '"id" : "' ${file} | sed -e 's|^.*"id" : "||g' -e 's|",$||g')
   fi
 
-  if [[ ! -d ${destination}${release_flower}/ ]] ; then
-    mkdir ${debug} -p ${destination}${release_flower}/
+  if [[ ! -d ${destination}${flower}/ ]] ; then
+    mkdir ${debug} -p ${destination}${flower}/
 
     let result=$?
     if [[ ${result} -ne 0 ]] ; then
-      echo "${p_e}Create directory failed (with system code ${result}) for destination: ${destination}${release_flower}/ ."
+      echo "${p_e}Create directory failed (with system code ${result}) for destination: ${destination}${flower}/ ."
 
       return ${result}
     fi
   fi
 
-  if [[ ${releases} != "" ]] ; then
+  if [[ ${releases} == "" ]] ; then
+    echo "Done: No releases to fetch from."
+  else
     for i in ${releases} ; do
 
-      if [[ -f ${destination}${release_flower}/${i} ]] ; then
+      if [[ -f ${destination}${flower}/${i} ]] ; then
         if [[ ${debug} != "" ]] ; then
-          echo "${p_d}Skipping existing Module Descriptor: ${destination}${release_flower}/${i} ."
+          echo "${p_d}Skipping existing Module Descriptor: ${destination}${flower}/${i} ."
           echo
         fi
 
@@ -176,15 +191,17 @@ main() {
         echo
       fi
 
-      curl -w '\n' ${debug} ${registry}${i} -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'cache-control: no-cache' -o ${destination}${release_flower}/${i}
+      curl -w '\n' ${debug} ${registry}${i} -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'cache-control: no-cache' -o ${destination}${flower}/${i}
 
       let result=$?
       if [[ ${result} -ne 0 ]] ; then
-        echo "${p_e}Curl request failed (with system code ${result}) for: ${registry}${i} to ${destination}${release_flower}/${i}."
+        echo "${p_e}Curl request failed (with system code ${result}) for: ${registry}${i} to ${destination}${flower}/${i}."
 
         return ${result}
       fi
     done
+
+    echo "Done: Module descriptors fetched as needed."
   fi
 
   return 0

--- a/script/sync_snapshot.sh
+++ b/script/sync_snapshot.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+#
+# Identify whether or not changes are detected and perform git push using the given key.
+#
+# This requires the following user-space programs:
+#   - bash
+#   - grep
+#   - git
+#
+#  Parameters:
+#    1) (optional) A message to use for the Git commit.
+#
+#  Environment Variables:
+#    SYNC_SNAPSHOT_DEBUG:   Enable debug verbosity, any non-empty string is enables this.
+#    SYNC_SNAPSHOT_MESSAGE: Specify a custom message to use for the commit.
+#    SYNC_SNAPSHOT_PATH:    Designate a path in which to analyze (default is an empty string, which means current directory).
+#    SYNC_SNAPSHOT_SIGN:    Set to "yes" to explicitly sign, set to "no" to explicitly not sign, and do not set (or set to empty string) to use user-space default.
+#
+# The SYNC_SNAPSHOT_DEBUG may be specifically set to "git" to include printing the git commands.
+# The SYNC_SNAPSHOT_DEBUG may be specifically set to "git_only" to only print the git commands, disabling all other debugging (does not pass -v to git).
+# Otherwise, any non-empty value will result in debug printing without the git command.
+#
+
+main() {
+  local debug=
+  local debug_git=
+  local path=
+  local signoff=
+  local changes=
+  local message="Synchronize Snapshot Update."
+
+  # Custom prefixes for debug and error.
+  local p_d="DEBUG: "
+  local p_e="ERROR: "
+
+  local -i result=0
+
+  if [[ ${1} != "" ]] ; then
+    message=${1}
+  fi
+
+  if [[ ${SYNC_SNAPSHOT_DEBUG} != "" ]] ; then
+    debug="-v"
+
+    if [[ ${SYNC_SNAPSHOT_DEBUG} == "git" ]] ; then
+      debug_git="y"
+    elif [[ ${SYNC_SNAPSHOT_DEBUG} == "git_only" ]] ; then
+      debug=""
+      debug_git="y"
+    elif [[ $(echo ${SYNC_SNAPSHOT_DEBUG} | grep -sho "_only") != "" ]] ; then
+      debug=""
+    elif [[ $(echo ${SYNC_SNAPSHOT_DEBUG} | grep -sho "\<git\>") != "" ]] ; then
+      debug_git="y"
+    fi
+  fi
+
+  if [[ ${SYNC_SNAPSHOT_MESSAGE} != "" ]] ; then
+    message="${SYNC_SNAPSHOT_MESSAGE}"
+  fi
+
+  if [[ ${SYNC_SNAPSHOT_PATH} != "" ]] ; then
+    path="${SYNC_SNAPSHOT_PATH}"
+  fi
+
+  if [[ ${SYNC_SNAPSHOT_SIGN} == "yes" ]] ; then
+    signoff="--no-signoff"
+  elif [[ ${SYNC_SNAPSHOT_SIGN} == "no" ]] ; then
+    signoff="--signoff"
+  fi
+
+  if [[ ${path} != "" ]] ; then
+    cd ${path}
+
+    let result=$?
+    if [[ ${result} -ne 0 ]] ; then
+      echo "${p_e}Failed (with system code ${result}) to change to path: ${path} ."
+
+      return ${result}
+    fi
+  fi
+
+  if [[ ${debug_git} != "" ]] ; then
+    print_git_debug "Determining" "git status --porcelain --untracked-files=yes | grep '.*' -sho"
+  fi
+
+  changes=$(git status --porcelain --untracked-files=yes | grep '.*' -sho)
+
+  if [[ ${changes} == "" ]] ; then
+    echo "Done: No changes to commit detected."
+  else
+    if [[ ${debug_git} != "" ]] ; then
+      print_git_debug "Adding" "git add -A ${debug}"
+    fi
+
+    git add -A ${debug}
+
+    let result=$?
+    if [[ ${result} -ne 0 ]] ; then
+      print_git_error "adding"
+
+      return ${result}
+    fi
+
+    if [[ ${debug_git} != "" ]] ; then
+      print_git_debug "Committing" "git commit -m \"${message}\" ${signoff} ${debug}"
+    fi
+
+    git commit -m "${message}" ${signoff} ${debug}
+
+    let result=$?
+    if [[ ${result} -ne 0 ]] ; then
+      print_git_error "committing"
+
+      return ${result}
+    fi
+
+    if [[ ${debug_git} != "" ]] ; then
+      print_git_debug "Pushing" "git push ${debug}"
+    fi
+
+    git push ${debug}
+
+    let result=$?
+    if [[ ${result} -ne 0 ]] ; then
+      print_git_error "pushing"
+
+      return ${result}
+    fi
+
+    echo "Done: Pushed detected changes."
+  fi
+
+  return 0
+}
+
+print_git_debug() {
+  echo "${p_d}${1} Git Changes: ${2} ."
+  echo
+}
+
+print_git_error() {
+  echo "${p_e}Git failed (with system code ${result}) when ${1} changes."
+}
+
+main $*


### PR DESCRIPTION
Add `workflow_dispatch:` to enable manual triggering of the GH Pages workflow.

Add Synchronize Snapshot workflow to execute once a day.

Allow for custom inputs, particularly for when manually triggering.

The Synchronize Snapshot workflow is expected to:
  - Checkout the scripts from the main branch.
  - Checkout the `snapshot` branch.
  - Populate the snapshot files using the `populate_release.sh` script.
  - Commit any new files using the `sync_snapshot.sh` script.

This uses the GitHub bot to perform the commits.

~This is not yet tested and may require additional changes.~

Fix some problems with the variable names in the `populate_release.sh` script where `_RELEASE` is added multiple times.
Refactor the `POPULATE_RELEASE_RELEASE` to `POPULATE_RELEASE_TARGET` to hopefully make it less confusing.
Change the defaults to operate for a `snapshot` release.
Change the environment variable processing to better allow for GitHub Actions where the variables might be defined as an empty string but should be treated as not defined at all.
Remove hard-coded `install.json` file usage, replacing it with the `${file}` variable.
Remove unneeded `-n` parameter from the `grep` command.