### PR TITLE
Separate gh_pages into two workflows.

### DIFF
--- a/.github/workflows/gh_pages-auto.yml
+++ b/.github/workflows/gh_pages-auto.yml
@@ -1,10 +1,8 @@
-name: gh_pages
+name: gh_pages-auto
 on:
   push:
     branches:
       - snapshot
-
-  workflow_dispatch:
 
 jobs:
   pages-directory-listing:

--- a/.github/workflows/gh_pages-manual.yml
+++ b/.github/workflows/gh_pages-manual.yml
@@ -1,0 +1,44 @@
+name: gh_pages-manual
+on:
+  workflow_dispatch:
+
+jobs:
+  pages-directory-listing:
+    runs-on: ubuntu-latest
+    name: Directory Listings Index
+    permissions:
+      contents: read  # Recommended checkout permissions.
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          ref: snapshot
+
+      - name: Generate Directory Listings
+        uses: jayanta525/github-pages-directory-listing@v4.0.0
+        with:
+          FOLDER: release  # Directory to generate index.
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'release'  # Upload generated folder.
+
+  deploy:
+    needs: pages-directory-listing
+    permissions:
+      pages: write     # To deploy to Pages.
+      id-token: write  # To verify the deployment originates from an appropriate source.
+
+    # Deploy to the github-pages environment.
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    # Specify runner + deployment step.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+


### PR DESCRIPTION
When a `workflow_dispatch` is present, the automatic action, such as `on push` is not triggering anymore.

Split this into two workflows to see if this resolves the problem.

Note: The problem might instead be the `on push` event is not triggered when the github bot performs the push. [This commit that updates the README in the `snapshot` branch confirms that the `on push` no longer works on any push and not just a bot](https://github.com/TAMULib/folio-module-descriptor-registry/commit/63f441eddb6179f3bfd78f0d8003f28e9057c7e2).