### PR TITLE
Utilize workflow_call and try to use word-characters only in job names.

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -1,13 +1,16 @@
-name: gh_pages
+name: Build Github Pages
+run-name: Build Github Pages by @${{ github.actor }}
 on:
   push:
     branches:
       - snapshot
 
+  workflow_call:
+
   workflow_dispatch:
 
 jobs:
-  pages-directory-listing:
+  build_github_pages:
     runs-on: ubuntu-latest
     name: Directory Listings Index
     permissions:
@@ -28,8 +31,8 @@ jobs:
         with:
           path: 'release'  # Upload generated folder.
 
-  deploy:
-    needs: pages-directory-listing
+  deploy_github_pages:
+    needs: build_github_pages
     permissions:
       pages: write     # To deploy to Pages.
       id-token: write  # To verify the deployment originates from an appropriate source.

--- a/.github/workflows/sync_snapshot.yml
+++ b/.github/workflows/sync_snapshot.yml
@@ -43,4 +43,5 @@ jobs:
           bash ../scripts/script/sync_snapshot.sh
 
   build_github_pages_workflow:
+    name: Build Github Pages Workflow
     uses: ./.github/workflows/gh_pages.yml

--- a/.github/workflows/sync_snapshot.yml
+++ b/.github/workflows/sync_snapshot.yml
@@ -1,4 +1,4 @@
-name: sync_snapshot
+name: Synchronize Snapshot
 run-name: Synchronize Snapshot by @${{ github.actor }}
 
 on:
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  run-script:
+  synchronize_snapshot:
     runs-on: ubuntu-latest
     name: Update Registry
     permissions:
@@ -41,3 +41,6 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           bash ../scripts/script/sync_snapshot.sh
+
+  build_github_pages_workflow:
+    uses: ./.github/workflows/gh_pages.yml


### PR DESCRIPTION
Enable and utilize `workflow_call` to have the Synchronize Snapshot workflow directly call the Build GitHub Pages workflow.

Use regular words rather than machine friendly words (no spaces, etc...) for the name to make the GitHub Actions interface easier to read.

This worked in some testing action: https://github.com/TAMULib/folio-module-descriptor-registry/actions/runs/13333455146

see: https://docs.github.com/en/actions/sharing-automations/reusing-workflows#calling-a-reusable-workflow