### PR TITLE
Provide Build Latest version links script and workflow.

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -12,10 +12,11 @@ on:
 
 jobs:
   build_github_pages:
-    runs-on: ubuntu-latest
     name: Directory Listings Index
     permissions:
       contents: read  # Recommended checkout permissions.
+
+    runs-on: self-hosted
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -35,6 +36,7 @@ jobs:
   deploy_github_pages:
     name: Deploy Github Pages
     needs: build_github_pages
+
     permissions:
       pages: write     # To deploy to Pages.
       id-token: write  # To verify the deployment originates from an appropriate source.
@@ -44,8 +46,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
 
-    # Specify runner + deployment step.
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -1,5 +1,5 @@
 name: Build Github Pages
-run-name: Build Github Pages by @${{ github.actor }}
+run-name: Build Github Pages using registry branch ${{ inputs.registry_branch }} by @${{ github.actor }}
 
 on:
   push:
@@ -7,8 +7,20 @@ on:
       - snapshot
 
   workflow_call:
+    inputs:
+      registry_branch:
+        description: 'Branch name to checkout the registry from.'
+        required: true
+        type: string
+        default: 'snapshot'
 
   workflow_dispatch:
+    inputs:
+      registry_branch:
+        description: 'Branch name to checkout the registry from.'
+        required: true
+        type: string
+        default: 'snapshot'
 
 jobs:
   build_github_pages:
@@ -21,7 +33,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          ref: snapshot
+          ref: ${{ inputs.registry_branch }}
 
       - name: Generate Directory Listings
         uses: jayanta525/github-pages-directory-listing@v4.0.0

--- a/.github/workflows/sync_snapshot.yml
+++ b/.github/workflows/sync_snapshot.yml
@@ -72,7 +72,7 @@ jobs:
         name: Build Latest Version Links
         working-directory: populate
         run: |
-          bash.BUILD_LATEST_IGNORE=setting/ignore.txt BUILD_LATEST_PATH=release/snapshot./scripts/script/build_latest.sh
+          BUILD_LATEST_IGNORE=setting/ignore.txt BUILD_LATEST_PATH=release/snapshot bash ../scripts/script/build_latest.sh
       - id: synchronize_snapshot
         name: Synchronize Snapshot
         working-directory: populate

--- a/.github/workflows/sync_snapshot.yml
+++ b/.github/workflows/sync_snapshot.yml
@@ -44,6 +44,11 @@ jobs:
         working-directory: populate
         run: |
           bash ../scripts/script/populate_release.sh
+      - id: build_latest
+        name: Build Latest Version Links
+        working-directory: populate
+        run: |
+          bash.BUILD_LATEST_IGNORE=setting/ignore.txt BUILD_LATEST_PATH=release/snapshot./scripts/script/build_latest.sh
       - id: synchronize_snapshot
         name: Synchronize Snapshot
         working-directory: populate

--- a/.github/workflows/sync_snapshot.yml
+++ b/.github/workflows/sync_snapshot.yml
@@ -9,12 +9,15 @@ on:
 
 jobs:
   synchronize_snapshot:
-    runs-on: ubuntu-latest
     name: Update Registry
+
     permissions:
       contents: write # To push the changes.
+
     outputs:
       sync_result: ${{ steps.synchronize_snapshot.outputs.sync_result }}
+
+    runs-on: self-hosted
     steps:
       - id: create_dirs
         name: Create Working Directories

--- a/.github/workflows/sync_snapshot.yml
+++ b/.github/workflows/sync_snapshot.yml
@@ -1,11 +1,35 @@
 name: Synchronize Snapshot
-run-name: Synchronize Snapshot by @${{ github.actor }}
+run-name: Synchronize Snapshot using script branch ${{ inputs.script_branch }} and registry branch ${{ inputs.registry_branch }} by @${{ github.actor }}
 
 on:
   schedule:
     - cron: '0 0 */1 * *'
 
+  workflow_call:
+    inputs:
+      script_branch:
+        description: 'Branch name to checkout scripts from.'
+        required: true
+        type: string
+        default: 'master'
+      registry_branch:
+        description: 'Branch name to checkout the registry from.'
+        required: true
+        type: string
+        default: 'snapshot'
+
   workflow_dispatch:
+    inputs:
+      script_branch:
+        description: 'Branch name to checkout scripts from.'
+        required: true
+        type: string
+        default: 'master'
+      registry_branch:
+        description: 'Branch name to checkout the registry from.'
+        required: true
+        type: string
+        default: 'snapshot'
 
 jobs:
   synchronize_snapshot:
@@ -20,15 +44,15 @@ jobs:
     runs-on: self-hosted
     steps:
       - id: create_dirs
-        name: Create Working Directories
+        name: Clean and Create Working Directories
         run: |
-          mkdir scripts
-          mkdir populate
+          rm -Rf populate scripts
+          mkdir populate scripts
       - id: checkout_scripts
         name: Checkout Scripts
         uses: actions/checkout@v4
         with:
-          ref: master
+          ref: ${{ inputs.script_branch }}
           path: scripts
           sparse-checkout: |
             script/populate_release.sh
@@ -37,7 +61,7 @@ jobs:
         name: Checkout Registry
         uses: actions/checkout@v4
         with:
-          ref: snapshot
+          ref: ${{ inputs.registry_branch }}
           path: populate
       - id: populate_snapshot
         name: Populate Snapshot
@@ -63,3 +87,5 @@ jobs:
     needs: synchronize_snapshot
     if: needs.synchronize_snapshot.outputs.sync_result == 'updates'
     uses: ./.github/workflows/gh_pages.yml
+    with:
+      registry_branch: ${{ inputs.registry_branch }}

--- a/README.md
+++ b/README.md
@@ -19,10 +19,25 @@ The Module Descriptors for each release are found within the `release/` subdirec
 This repository provides additional scripts that may help facilitate the generation of the Module Descriptors.
 
 
+## Build Latest
+
+The **Build Latest** scripts provides a simple but automated way to create module descriptor symbolic links referencing the latest version.
+This script takes a simple approach of creating a symoblic link to the version specified by the given `install.json` files in the order in which they appear.
+
+The order in which the files are passed determines the order (left to right) in which overwrities of existing symbolic links are performed.
+The default behavior is to use the "-latest" in place of the version suffix.
+
+View the documentation within the `build_latest.sh` script for further details on how to operate this script.
+
+Example usage:
+```shell
+BUILD_LATEST_PATH="release/snapshot" bash script/build_latest.sh install.json additional.json
+```
+
 ### Populate Release
 
 The **Populate Release** script helps automate building a list of module versions based on a specific flower release.
-This release is then used to fetch all of the available module descriptors from an upstream source, such as those found on the **FOLIO Registry**.
+This release is then used to fetch all of the available module descriptors from an upstream source (an `install.json` file), such as those found on the **FOLIO Registry**.
 
 This script is designed to accept environment variables, thereby allowing for easier integration with automation tools such as Docker.
 

--- a/script/build_latest.sh
+++ b/script/build_latest.sh
@@ -13,7 +13,7 @@
 #    *) A list of install.json file names to parse (order sensative).
 #
 #  Environment Variables:
-#    BUILD_LATEST_DEBUG:  Enable debug verbosity, any non-empty string is enables this.
+#    BUILD_LATEST_DEBUG:  Enable debug verbosity, any non-empty string enables this.
 #    BUILD_LATEST_FILES:  A list of files to build (applied before the command line arguments).
 #    BUILD_LATEST_IGNORE: A path to a space and new line separated file (such as "setting/ignore.txt") representing module names to ignore.
 #    BUILD_LATEST_PATH:   The destination path to write to.

--- a/script/build_latest.sh
+++ b/script/build_latest.sh
@@ -60,9 +60,9 @@ build_latest_load_environment() {
     elif [[ ${BUILD_LATEST_DEBUG} == "json_only" ]] ; then
       debug=""
       debug_json="y"
-    elif [[ $(echo ${SYNC_SNAPSHOT_DEBUG} | grep -sho "_only") != "" ]] ; then
+    elif [[ $(echo ${BUILD_LATEST_DEBUG} | grep -sho "_only") != "" ]] ; then
       debug=""
-    elif [[ $(echo ${SYNC_SNAPSHOT_DEBUG} | grep -sho "\<json\>") != "" ]] ; then
+    elif [[ $(echo ${BUILD_LATEST_DEBUG} | grep -sho "\<json\>") != "" ]] ; then
       debug_json="y"
     fi
   fi

--- a/script/build_latest.sh
+++ b/script/build_latest.sh
@@ -157,7 +157,7 @@ build_latest_operate() {
 
   for i in ${files} ; do
 
-    releases=$(grep -sh '"id" : "' ${i} | sed -e 's|^.*"id" : "||g' -e 's|",$||g')
+    releases=$(jq -M '.[].id' ${i} | sed -e 's|"||g')
 
     for j in ${releases} ; do
 
@@ -218,9 +218,9 @@ build_latest_verify_files() {
 
       # Prevent jq from printing JSON if /dev/null exists when not debugging.
       if [[ ${debug_json} != "" || ! -e /dev/null ]] ; then
-        cat ${i} | jq
+        jq -M '.[]' ${i}
       else
-        cat ${i} | jq >> /dev/null
+        jq -M '.[]' >> /dev/null
       fi
 
       if [[ ${?} -ne 0 ]] ; then

--- a/script/build_latest.sh
+++ b/script/build_latest.sh
@@ -1,0 +1,241 @@
+#!/bin/bash
+#
+# Determine the latest version and make symbolic links with "-latest" in place of the version suffix.
+#
+# This requires the following user-space programs:
+#   - bash
+#   - cat
+#   - grep
+#   - jq
+#   - sed
+#
+#  Parameters:
+#    *) A list of install.json file names to parse (order sensative).
+#
+#  Environment Variables:
+#    BUILD_LATEST_DEBUG:  Enable debug verbosity, any non-empty string is enables this.
+#    BUILD_LATEST_FILES:  A list of files to build (applied before the command line arguments).
+#    BUILD_LATEST_IGNORE: A path to a space and new line separated file (such as "setting/ignore.txt") representing module names to ignore.
+#    BUILD_LATEST_PATH:   The destination path to write to.
+#
+# The BUILD_LATEST_DEBUG may be specifically set to "json" to include printing the JSON files.
+# The BUILD_LATEST_DEBUG may be specifically set to "json_only" to only print the JSON files, disabling all other debugging (does not pass -v).
+# Otherwise, any non-empty value will result in debug printing without the git command.
+#
+# If neither the BUILD_LATEST_FILES nor the command line parameter files are passed then the default file is used.
+#
+
+main() {
+  local debug=
+  local debug_json=
+  local default_file="install.json"
+  local files=
+  local i=
+  local ignore=
+  local path=
+
+  # Custom prefixes for debug and error.
+  local p_d="DEBUG: "
+  local p_e="ERROR: "
+
+  local -i result=0
+
+  build_latest_load_environment ${*}
+
+  build_latest_verify_files
+
+  build_latest_operate
+
+  return ${result}
+}
+
+build_latest_load_environment() {
+  local file=
+
+  if [[ ${BUILD_LATEST_DEBUG} != "" ]] ; then
+    debug="-v"
+
+    if [[ ${BUILD_LATEST_DEBUG} == "json" ]] ; then
+      debug_json="y"
+    elif [[ ${BUILD_LATEST_DEBUG} == "json_only" ]] ; then
+      debug=""
+      debug_json="y"
+    elif [[ $(echo ${SYNC_SNAPSHOT_DEBUG} | grep -sho "_only") != "" ]] ; then
+      debug=""
+    elif [[ $(echo ${SYNC_SNAPSHOT_DEBUG} | grep -sho "\<json\>") != "" ]] ; then
+      debug_json="y"
+    fi
+  fi
+
+  if [[ ${BUILD_LATEST_FILES} != "" ]] ; then
+    file=$(echo ${BUILD_LATEST_FILES} | sed -e 's|//*|/|g' -e 's|/*$|/|g')
+
+    if [[ -f ${BUILD_LATEST_FILES} ]] ; then
+      for i in $(cat ${BUILD_LATEST_FILES}) ; do
+        build_latest_print_debug "Using File: ${i}"
+
+        files="${files}${i} "
+      done
+    else
+      echo "${p_e}The following path is not a valid directory: ${path} ."
+
+      let result=1
+
+      return
+    fi
+
+    file=
+  fi
+
+  if [[ ${BUILD_LATEST_IGNORE} != "" ]] ; then
+    file=$(cat ${BUILD_LATEST_IGNORE} | sed -e 's|^\s*||' -e 's|\s*$||')
+
+    if [[ ${file} != "" ]] ; then
+      for i in ${file} ; do
+        ignore="${ignore}${i} "
+      done
+    fi
+
+    file=
+  fi
+
+  # Load files from the command line parameters.
+  if [[ ${#} -gt 0 ]] ; then
+    let i=1
+
+    while [[ ${i} -le ${#} ]] ; do
+
+      # Note: In ZSH this would instead be: file=${(P)i}.
+      file=${!i}
+
+      build_latest_print_debug "Using File: ${file}"
+
+      files="${files}${file} "
+
+      let i++
+    done
+  fi
+
+  if [[ ${files} == "" ]] ; then
+    files=${default_file}
+  fi
+
+  if [[ ${BUILD_LATEST_PATH} != "" ]] ; then
+    path=$(echo -n ${BUILD_LATEST_PATH} | sed -e 's|//*|/|g' -e 's|/*$|/|g')
+
+    if [[ ${path} != "" ]] ; then
+      if [[ -e ${path} ]] ; then
+        if [[ ! -d ${path} ]] ; then
+          echo "${p_e}The following path is not a valid directory: ${path} ."
+
+          let result=1
+        fi
+      else
+        mkdir ${debug} -p ${path}
+
+        build_latest_handle_result "${p_e}The following path is could not be created: ${path} ."
+      fi
+    fi
+  fi
+}
+
+build_latest_handle_result() {
+  let result=$?
+
+  if [[ ${result} -ne 0 ]] ; then
+    echo "${1}"
+  fi
+}
+
+build_latest_operate() {
+  local release=
+  local releases=
+  local j=
+  local version=
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  for i in ${files} ; do
+
+    releases=$(grep -sh '"id" : "' ${i} | sed -e 's|^.*"id" : "||g' -e 's|",$||g')
+
+    for j in ${releases} ; do
+
+      # Skip any files without the dash in the name used to provide a version.
+      if [[ $(echo ${j} | grep -sho '-') == "" ]] ; then
+        continue
+      fi
+
+      release=$(echo -n ${j} | sed -e "s|-SNAPSHOT*||" -e "s|-[^-]*$||" -e 's|"||g')
+
+      if [[ $(echo -n ${ignore} | grep -sho "\<${release}\>") != "" ]] ; then
+        build_latest_print_debug "Ignoring from ${i}: ${release}"
+
+        continue;
+      fi
+
+      if [[ ! -f ${path}${j} ]] ; then
+        echo "${p_e}Cannot find the version file to link to: ${path}${j} ."
+
+        let result=1
+
+        return
+      fi
+
+      ln -vsf ${j} ${path}${release}-latest
+
+      build_latest_handle_result
+
+      if [[ ${result} -ne 0 ]] ; then return ; fi
+    done
+  done
+
+  echo "Done: Latest versions are built."
+}
+
+build_latest_print_debug() {
+
+  if [[ ${debug} == "" ]] ; then return ; fi
+
+  echo "${p_d}${1} ."
+  echo
+}
+
+build_latest_verify_files() {
+  local problems=
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  if [[ ${files} != "" ]] ; then
+    for i in ${files} ; do
+      build_latest_print_debug "Verifying File: ${i}"
+
+      if [[ ! -f ${i} ]] ; then
+        problems="${problems}${i} "
+
+        continue
+      fi
+
+      # Prevent jq from printing JSON if /dev/null exists when not debugging.
+      if [[ ${debug_json} != "" || ! -e /dev/null ]] ; then
+        cat ${i} | jq
+      else
+        cat ${i} | jq >> /dev/null
+      fi
+
+      if [[ ${?} -ne 0 ]] ; then
+        problems="${problems}${i} "
+      fi
+    done
+  fi
+
+  if [[ ${problems} != "" ]] ; then
+    echo "${p_e}Build Latest failed, the following are either missing or invalid files: ${problems}."
+
+    if [[ ${result} -eq 0 ]] ; then
+      let result=1
+    fi
+  fi
+}
+
+main ${*}

--- a/script/build_latest.sh
+++ b/script/build_latest.sh
@@ -88,15 +88,17 @@ build_latest_load_environment() {
   fi
 
   if [[ ${BUILD_LATEST_IGNORE} != "" ]] ; then
-    file=$(cat ${BUILD_LATEST_IGNORE} | sed -e 's|^\s*||' -e 's|\s*$||')
+    if [[ -f ${BUILD_LATEST_IGNORE} ]] ; then
+      file=$(cat ${BUILD_LATEST_IGNORE} | sed -e 's|^\s*||' -e 's|\s*$||')
 
-    if [[ ${file} != "" ]] ; then
-      for i in ${file} ; do
-        ignore="${ignore}${i} "
-      done
+      if [[ ${file} != "" ]] ; then
+        for i in ${file} ; do
+          ignore="${ignore}${i} "
+        done
+      fi
+
+      file=
     fi
-
-    file=
   fi
 
   # Load files from the command line parameters.

--- a/script/build_latest.sh
+++ b/script/build_latest.sh
@@ -220,9 +220,9 @@ build_latest_verify_files() {
 
       # Prevent jq from printing JSON if /dev/null exists when not debugging.
       if [[ ${debug_json} != "" || ! -e /dev/null ]] ; then
-        jq -M '.[]' ${i}
+        cat ${i} | jq
       else
-        jq -M '.[]' >> /dev/null
+        cat ${i} | jq >> /dev/null
       fi
 
       if [[ ${?} -ne 0 ]] ; then

--- a/script/populate_release.sh
+++ b/script/populate_release.sh
@@ -13,10 +13,10 @@
 #    2) (optional) The Flower release name, such as "quesnelia" or "snapshot", used to create the destination directory.
 #
 #  Environment Variables:
-#    POPULATE_RELEASE_DEBUG:           Enable debug verbosity, any non-empty string is enables this.
+#    POPULATE_RELEASE_DEBUG:           Enable debug verbosity, any non-empty string enables this.
 #    POPULATE_RELEASE_DESTINATION:     Destination parent directory.
 #    POPULATE_RELEASE_FILE:            The name of the install.json file as it is stored locally after GET fetching.
-#    POPULATE_RELEASE_FILE_REUSE:      Enable re-using existing install.json file without GET fetching, any non-empty string is enables this.
+#    POPULATE_RELEASE_FILE_REUSE:      Enable re-using existing install.json file without GET fetching, any non-empty string enables this.
 #    POPULATE_RELEASE_FLOWER:          The Flower release name; If specified, then the associated parameter is ignored.
 #    POPULATE_RELEASE_REGISTRY:        The URL to GET the module descriptor from for some specific module version.
 #    POPULATE_RELEASE_REPOSITORY:      The raw GitHub repository URL to fetch from (but without the URL parts after the repository name).

--- a/script/populate_release.sh
+++ b/script/populate_release.sh
@@ -53,64 +53,7 @@ main() {
 
   local -i result=0
 
-  if [[ ${1} != "" ]] ; then
-    target=$(echo ${1} | sed -e 's|/||g')
-  fi
-
-  if [[ ${2} != "" ]] ; then
-    flower=$(echo ${2} | sed -e 's|/||g')
-  fi
-
-  if [[ ${POPULATE_RELEASE_DEBUG} != "" ]] ; then
-    debug="-v"
-    debug_curl=""
-
-    if [[ ${POPULATE_RELEASE_DEBUG} == "curl" ]] ; then
-      debug_curl="y"
-    elif [[ ${POPULATE_RELEASE_DEBUG} == "curl_only" ]] ; then
-      debug=""
-      debug_curl="y"
-    elif [[ $(echo ${POPULATE_RELEASE_DEBUG} | grep -sho "_only") != "" ]] ; then
-      debug=""
-    elif [[ $(echo ${POPULATE_RELEASE_DEBUG} | grep -sho "\<curl\>") != "" ]] ; then
-      debug_curl="y"
-    fi
-  fi
-
-  if [[ ${POPULATE_RELEASE_DESTINATION} != "" ]] ; then
-    destination=$(echo ${POPULATE_RELEASE_DESTINATION} | sed -e 's|/*$|/|g')
-  fi
-
-  if [[ ${POPULATE_RELEASE_FILE} != "" ]] ; then
-    file=$(echo ${POPULATE_RELEASE_FILE} | sed -e 's|/*$||')
-  fi
-
-  if [[ ${POPULATE_RELEASE_REGISTRY} != "" ]] ; then
-    registry=$(echo ${POPULATE_RELEASE_REGISTRY} | sed -e 's|/*$|/|g')
-  fi
-
-  if [[ ${POPULATE_RELEASE_TARGET} != "" ]] ; then
-    target=$(echo ${POPULATE_RELEASE_TARGET} | sed -e 's|/||g')
-  fi
-
-  if [[ ${POPULATE_RELEASE_FLOWER} != "" ]] ; then
-    flower=$(echo ${POPULATE_RELEASE_FLOWER} | sed -e 's|/||g')
-  fi
-
-  if [[ ${POPULATE_RELEASE_REPOSITORY} != "" ]] ; then
-    repository=$(echo ${POPULATE_RELEASE_REPOSITORY} | sed -e 's|/*$|/|g')
-  fi
-
-  # May be empty, so use "-v" test rather than != "".
-  if [[ -v POPULATE_RELEASE_REPOSITORY_PART ]] ; then
-    part=${POPULATE_RELEASE_REPOSITORY_PART}
-  fi
-
-  if [[ ${part} != "" ]] ; then
-    part="refs/$(echo ${part} | sed -e 's|/*$|/|g')"
-  fi
-
-  source="$(echo ${repository} | sed -e 's|/*$|/|')${part}${target}/${file}"
+  pop_rel_load_environment
 
   if [[ ${POPULATE_RELEASE_FILE_REUSE} != "" ]] ; then
     if [[ ! -f ${file} ]] ; then
@@ -132,6 +75,8 @@ main() {
 }
 
 pop_rel_curl_releases() {
+  local release=
+  local version=
 
   if [[ ${result} -ne 0 ]] ; then return ; fi
 
@@ -142,6 +87,11 @@ pop_rel_curl_releases() {
   fi
 
   for i in ${releases} ; do
+
+    # Skip any files without the dash in the name used to provide a version.
+    if [[ $(echo ${i} | grep -sho '-') == "" ]] ; then
+      continue
+    fi
 
     if [[ -f ${destination}${flower}/${i} ]] ; then
       if [[ ${debug} != "" ]] ; then
@@ -169,6 +119,68 @@ pop_rel_curl_releases() {
   done
 
   echo "Done: Module descriptors fetched as needed."
+}
+
+pop_rel_load_environment() {
+
+  if [[ ${1} != "" ]] ; then
+    target=$(echo ${1} | sed -e 's|/||g')
+  fi
+
+  if [[ ${2} != "" ]] ; then
+    flower=$(echo ${2} | sed -e 's|/||g')
+  fi
+
+  if [[ ${POPULATE_RELEASE_DEBUG} != "" ]] ; then
+    debug="-v"
+    debug_curl=""
+
+    if [[ ${POPULATE_RELEASE_DEBUG} == "curl" ]] ; then
+      debug_curl="y"
+    elif [[ ${POPULATE_RELEASE_DEBUG} == "curl_only" ]] ; then
+      debug=""
+      debug_curl="y"
+    elif [[ $(echo ${POPULATE_RELEASE_DEBUG} | grep -sho "_only") != "" ]] ; then
+      debug=""
+    elif [[ $(echo ${POPULATE_RELEASE_DEBUG} | grep -sho "\<curl\>") != "" ]] ; then
+      debug_curl="y"
+    fi
+  fi
+
+  if [[ ${POPULATE_RELEASE_DESTINATION} != "" ]] ; then
+    destination=$(echo ${POPULATE_RELEASE_DESTINATION} | sed -e 's|//*|/|g' -e 's|/*$|/|g')
+  fi
+
+  if [[ ${POPULATE_RELEASE_FILE} != "" ]] ; then
+    file=$(echo ${POPULATE_RELEASE_FILE} | sed -e 's|//*|/|g' -e 's|/*$||')
+  fi
+
+  if [[ ${POPULATE_RELEASE_REGISTRY} != "" ]] ; then
+    registry=$(echo ${POPULATE_RELEASE_REGISTRY} | sed -e 's|//*|/|g' -e 's|/*$|/|g')
+  fi
+
+  if [[ ${POPULATE_RELEASE_TARGET} != "" ]] ; then
+    target=$(echo ${POPULATE_RELEASE_TARGET} | sed -e 's|/||g')
+  fi
+
+  if [[ ${POPULATE_RELEASE_FLOWER} != "" ]] ; then
+    flower=$(echo ${POPULATE_RELEASE_FLOWER} | sed -e 's|/||g')
+  fi
+
+  if [[ ${POPULATE_RELEASE_REPOSITORY} != "" ]] ; then
+    repository=$(echo ${POPULATE_RELEASE_REPOSITORY} | sed -e 's|//*|/|g' -e 's|/*$|/|g')
+  fi
+
+  # May be empty, so use "-v" test rather than != "".
+  if [[ -v POPULATE_RELEASE_REPOSITORY_PART ]] ; then
+    part=${POPULATE_RELEASE_REPOSITORY_PART}
+  fi
+
+  if [[ ${part} != "" ]] ; then
+    part="refs/$(echo ${part} | sed -e 's|//*|/|g' -e 's|/*$|/|g')"
+  fi
+
+  source="$(echo ${repository} | sed -e 's|//*|/|g' -e 's|/*$|/|')${part}${target}/${file}"
 }
 
 pop_rel_prepare_source() {
@@ -203,7 +215,7 @@ pop_rel_prepare_releases() {
   if [[ ${result} -ne 0 ]] ; then return ; fi
 
   if [[ -f ${file} ]] ; then
-    releases=$(grep -shr '"id" : "' ${file} | sed -e 's|^.*"id" : "||g' -e 's|",$||g')
+    releases=$(grep -sh '"id" : "' ${file} | sed -e 's|^.*"id" : "||g' -e 's|",$||g')
   fi
 
   if [[ ! -d ${destination}${flower}/ ]] ; then

--- a/script/populate_release.sh
+++ b/script/populate_release.sh
@@ -6,6 +6,7 @@
 #   - bash
 #   - curl
 #   - grep
+#   - jq
 #   - sed
 #
 #  Parameters:
@@ -215,7 +216,7 @@ pop_rel_prepare_releases() {
   if [[ ${result} -ne 0 ]] ; then return ; fi
 
   if [[ -f ${file} ]] ; then
-    releases=$(grep -sh '"id" : "' ${file} | sed -e 's|^.*"id" : "||g' -e 's|",$||g')
+    releases=$(jq -M '.[].id' ${file} | sed -e 's|"||g')
   fi
 
   if [[ ! -d ${destination}${flower}/ ]] ; then

--- a/script/sync_snapshot.sh
+++ b/script/sync_snapshot.sh
@@ -11,7 +11,7 @@
 #    1) (optional) A message to use for the Git commit.
 #
 #  Environment Variables:
-#    SYNC_SNAPSHOT_DEBUG:   Enable debug verbosity, any non-empty string is enables this.
+#    SYNC_SNAPSHOT_DEBUG:   Enable debug verbosity, any non-empty string enables this.
 #    SYNC_SNAPSHOT_MESSAGE: Specify a custom message to use for the commit.
 #    SYNC_SNAPSHOT_PATH:    Designate a path in which to analyze (default is an empty string, which means current directory).
 #    SYNC_SNAPSHOT_RESULT:  The file name to write the results of this script to.

--- a/script/sync_snapshot.sh
+++ b/script/sync_snapshot.sh
@@ -39,44 +39,7 @@ main() {
 
   local -i result=0
 
-  if [[ ${1} != "" ]] ; then
-    message=${1}
-  fi
-
-  if [[ ${SYNC_SNAPSHOT_DEBUG} != "" ]] ; then
-    debug="-v"
-
-    if [[ ${SYNC_SNAPSHOT_DEBUG} == "git" ]] ; then
-      debug_git="y"
-    elif [[ ${SYNC_SNAPSHOT_DEBUG} == "git_only" ]] ; then
-      debug=""
-      debug_git="y"
-    elif [[ $(echo ${SYNC_SNAPSHOT_DEBUG} | grep -sho "_only") != "" ]] ; then
-      debug=""
-    elif [[ $(echo ${SYNC_SNAPSHOT_DEBUG} | grep -sho "\<git\>") != "" ]] ; then
-      debug_git="y"
-    fi
-  fi
-
-  if [[ ${SYNC_SNAPSHOT_MESSAGE} != "" ]] ; then
-    message="${SYNC_SNAPSHOT_MESSAGE}"
-  fi
-
-  if [[ ${SYNC_SNAPSHOT_PATH} != "" ]] ; then
-    path="${SYNC_SNAPSHOT_PATH}"
-  fi
-
-  if [[ ${SYNC_SNAPSHOT_SIGN} == "yes" ]] ; then
-    signoff="--no-signoff"
-  elif [[ ${SYNC_SNAPSHOT_SIGN} == "no" ]] ; then
-    signoff="--signoff"
-  fi
-
-  if [[ ${path} != "" ]] ; then
-    cd ${path}
-
-    sync_snap_handle_result "${p_e}Failed (with system code ${result}) to change to path: ${path} ."
-  fi
+  sync_snap_load_environment
 
   sync_snap_determine
 
@@ -155,6 +118,48 @@ sync_snap_handle_result_git() {
 
   if [[ ${result} -ne 0 ]] ; then
     echo "${p_e}Git failed (with system code ${result}) when ${1} changes."
+  fi
+}
+
+sync_snap_load_environment() {
+
+  if [[ ${1} != "" ]] ; then
+    message=${1}
+  fi
+
+  if [[ ${SYNC_SNAPSHOT_DEBUG} != "" ]] ; then
+    debug="-v"
+
+    if [[ ${SYNC_SNAPSHOT_DEBUG} == "git" ]] ; then
+      debug_git="y"
+    elif [[ ${SYNC_SNAPSHOT_DEBUG} == "git_only" ]] ; then
+      debug=""
+      debug_git="y"
+    elif [[ $(echo ${SYNC_SNAPSHOT_DEBUG} | grep -sho "_only") != "" ]] ; then
+      debug=""
+    elif [[ $(echo ${SYNC_SNAPSHOT_DEBUG} | grep -sho "\<git\>") != "" ]] ; then
+      debug_git="y"
+    fi
+  fi
+
+  if [[ ${SYNC_SNAPSHOT_MESSAGE} != "" ]] ; then
+    message="${SYNC_SNAPSHOT_MESSAGE}"
+  fi
+
+  if [[ ${SYNC_SNAPSHOT_PATH} != "" ]] ; then
+    path="${SYNC_SNAPSHOT_PATH}"
+  fi
+
+  if [[ ${SYNC_SNAPSHOT_SIGN} == "yes" ]] ; then
+    signoff="--no-signoff"
+  elif [[ ${SYNC_SNAPSHOT_SIGN} == "no" ]] ; then
+    signoff="--signoff"
+  fi
+
+  if [[ ${path} != "" ]] ; then
+    cd ${path}
+
+    sync_snap_handle_result "${p_e}Failed (with system code ${result}) to change to path: ${path} ."
   fi
 }
 

--- a/script/sync_snapshot.sh
+++ b/script/sync_snapshot.sh
@@ -79,9 +79,9 @@ sync_snap_determine() {
 
   if [[ ${result} -ne 0 ]] ; then return ; fi
 
-  sync_snap_print_git_debug "Determining" "git status --porcelain --untracked-files | grep '.*' -sho"
+  sync_snap_print_git_debug "Determining" "git status --porcelain --untracked-files"
 
-  changes=$(git status --porcelain --untracked-files | grep '.*' -sho)
+  changes=$(git status --porcelain --untracked-files)
 
   if [[ ${changes} != "" ]] ; then
     updated="updates"

--- a/script/sync_snapshot.sh
+++ b/script/sync_snapshot.sh
@@ -79,9 +79,9 @@ sync_snap_determine() {
 
   if [[ ${result} -ne 0 ]] ; then return ; fi
 
-  sync_snap_print_git_debug "Determining" "git status --porcelain --untracked-files=yes | grep '.*' -sho"
+  sync_snap_print_git_debug "Determining" "git status --porcelain --untracked-files | grep '.*' -sho"
 
-  changes=$(git status --porcelain --untracked-files=yes | grep '.*' -sho)
+  changes=$(git status --porcelain --untracked-files | grep '.*' -sho)
 
   if [[ ${changes} != "" ]] ; then
     updated="updates"


### PR DESCRIPTION
This script is designed to supplement both the `populate_release.sh` script and the `gh_pages.yml` workflow.

This provides a way to automatically represent the latest version using the `-latest` version tag rather than the explicit version. This should help improve the CI/CD integration and related tasks.

This uses an incredibly simple version number stripping based on existing data patterns. There is a good chance, due to its simplicity, than any unusual or different versioning will result in some problems in the generation of the `-latest`.

This provides a ignore setting to allow for not building the latest version link for any particular module.

This fixes some observed mistakes in the `populate_release.sh` script. Perform some structural re-organization for both the `populate_release.sh` and the `sync_snapshot.sh` scripts.

A stubbed out (empty) `setting/ignore.txt` is provided.

Note that this is based on the same branch as PR https://github.com/TAMULib/folio-module-descriptor-registry/pull/11. Therefore, this will contain some changes from that PR. See that PR for a description of changes.