### PR TITLE
Add GitHub Pages generator, improve parallel safety, and miscellaneous fixes.

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -8,11 +8,21 @@ on:
 
   workflow_call:
     inputs:
+      debug_mode:
+        description: 'Debug mode flags.'
+        required: false
+        type: string
+        default: ''
       registry_branch:
         description: 'Branch name to checkout the registry from.'
         required: true
         type: string
         default: 'snapshot'
+      script_branch:
+        description: 'Branch name to checkout scripts from.'
+        required: true
+        type: string
+        default: 'master'
 
   workflow_dispatch:
     inputs:
@@ -21,29 +31,74 @@ on:
         required: true
         type: string
         default: 'snapshot'
+      script_branch:
+        description: 'Branch name to checkout scripts from.'
+        required: true
+        type: string
+        default: 'master'
+      debug_mode:
+        description: 'Debug mode flags.'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   build_github_pages:
     name: Directory Listings Index
     permissions:
-      contents: read  # Recommended checkout permissions.
+      contents: read # Recommended checkout permissions.
+    outputs:
+      instance: ${{ steps.initialize_instance.outputs.instance }} # Help make parallel execution safer.
 
     runs-on: self-hosted
     steps:
-      - name: Checkout Repository
+      - id: initialize_instance
+        name: Initialize Instance
+        run: |
+          export THIS_INSTANCE="run_${RANDOM}"
+          echo "Running with instance: ${THIS_INSTANCE}"
+          echo "instance=${THIS_INSTANCE}" >> "${GITHUB_OUTPUT}"
+
+      - id: create_dirs
+        name: Clean and Create Working Directories
+        run: |
+          rm -Rf ${{steps.initialize_instance.outputs.instance}}/{populate,scripts,work}
+          mkdir -p ${{steps.initialize_instance.outputs.instance}}/{populate,scripts,work}
+
+      - id: checkout_registry
+        name: Checkout Registry
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.registry_branch }}
+          path: ${{steps.initialize_instance.outputs.instance}}/populate
+
+      - id: checkout_scripts
+        name: Checkout Scripts
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.script_branch }}
+          path: ${{steps.initialize_instance.outputs.instance}}/scripts
+          sparse-checkout: |
+            script/build_pages.sh
+            setting
+            template
 
       - name: Generate Directory Listings
-        uses: jayanta525/github-pages-directory-listing@v4.0.0
-        with:
-          FOLDER: release  # Directory to generate index.
+        working-directory: ${{steps.initialize_instance.outputs.instance}}/populate
+        run: |
+          BUILD_PAGES_DEBUG="${{ inputs.debug_mode }}" BUILD_PAGES_WORK="../work" BUILD_PAGES_TEMPLATE_PATH="../scripts/template" bash ../scripts/script/build_pages.sh release/
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: 'release'  # Upload generated folder.
+          path: ${{steps.initialize_instance.outputs.instance}}/work
+
+      - id: clean_up
+        name: Clean Up
+        working-directory: ${{steps.initialize_instance.outputs.instance}}
+        run: |
+          cd ..
+          rm -Rf ${{steps.initialize_instance.outputs.instance}}
 
   deploy_github_pages:
     name: Deploy Github Pages
@@ -53,7 +108,6 @@ jobs:
       pages: write     # To deploy to Pages.
       id-token: write  # To verify the deployment originates from an appropriate source.
 
-    # Deploy to the github-pages environment.
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/sync_snapshot.yml
+++ b/.github/workflows/sync_snapshot.yml
@@ -7,29 +7,39 @@ on:
 
   workflow_call:
     inputs:
-      script_branch:
-        description: 'Branch name to checkout scripts from.'
-        required: true
+      debug_mode:
+        description: 'Debug mode flags.'
+        required: false
         type: string
-        default: 'master'
+        default: ''
       registry_branch:
         description: 'Branch name to checkout the registry from.'
         required: true
         type: string
         default: 'snapshot'
+      script_branch:
+        description: 'Branch name to checkout scripts from.'
+        required: true
+        type: string
+        default: 'master'
 
   workflow_dispatch:
     inputs:
-      script_branch:
-        description: 'Branch name to checkout scripts from.'
-        required: true
-        type: string
-        default: 'master'
       registry_branch:
         description: 'Branch name to checkout the registry from.'
         required: true
         type: string
         default: 'snapshot'
+      script_branch:
+        description: 'Branch name to checkout scripts from.'
+        required: true
+        type: string
+        default: 'master'
+      debug_mode:
+        description: 'Debug mode flags.'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   synchronize_snapshot:
@@ -39,48 +49,69 @@ jobs:
       contents: write # To push the changes.
 
     outputs:
+      instance: ${{ steps.initialize_instance.outputs.instance }} # Help make parallel execution safer.
       sync_result: ${{ steps.synchronize_snapshot.outputs.sync_result }}
 
     runs-on: self-hosted
     steps:
+      - id: initialize_instance
+        name: Initialize Instance
+        run: |
+          export THIS_INSTANCE="run_${RANDOM}"
+          echo "Running with instance: ${THIS_INSTANCE}"
+          echo "instance=${THIS_INSTANCE}" >> "${GITHUB_OUTPUT}"
+
       - id: create_dirs
         name: Clean and Create Working Directories
         run: |
-          rm -Rf populate scripts
-          mkdir populate scripts
-      - id: checkout_scripts
-        name: Checkout Scripts
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.script_branch }}
-          path: scripts
-          sparse-checkout: |
-            script/populate_release.sh
-            script/sync_snapshot.sh
+          rm -Rf ${{steps.initialize_instance.outputs.instance}}/{populate,scripts}
+          mkdir -p ${{steps.initialize_instance.outputs.instance}}/{populate,scripts}
+
       - id: checkout_registry
         name: Checkout Registry
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.registry_branch }}
-          path: populate
+          path: ${{steps.initialize_instance.outputs.instance}}/populate
+
+      - id: checkout_scripts
+        name: Checkout Scripts
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.script_branch }}
+          path: ${{steps.initialize_instance.outputs.instance}}/scripts
+          sparse-checkout: |
+            script/populate_release.sh
+            script/sync_snapshot.sh
+            setting
+
       - id: populate_snapshot
         name: Populate Snapshot
-        working-directory: populate
+        working-directory: ${{steps.initialize_instance.outputs.instance}}/populate
         run: |
-          bash ../scripts/script/populate_release.sh
+          POPULATE_RELEASE_DEBUG="${{ inputs.debug_mode }}" bash ../scripts/script/populate_release.sh
+
       - id: build_latest
         name: Build Latest Version Links
-        working-directory: populate
+        working-directory: ${{steps.initialize_instance.outputs.instance}}/populate
         run: |
-          BUILD_LATEST_IGNORE=setting/ignore.txt BUILD_LATEST_PATH=release/snapshot bash ../scripts/script/build_latest.sh
+          BUILD_LATEST_DEBUG="${{ inputs.debug_mode }}" BUILD_LATEST_IGNORE=../scripts/setting/ignore.txt BUILD_LATEST_PATH=release/snapshot bash ../scripts/script/build_latest.sh
+
       - id: synchronize_snapshot
         name: Synchronize Snapshot
-        working-directory: populate
+        working-directory: ${{steps.initialize_instance.outputs.instance}}/populate
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          SYNC_SNAPSHOT_RESULT="results.txt" bash ../scripts/script/sync_snapshot.sh
+          SYNC_SNAPSHOT_DEBUG="${{ inputs.debug_mode }}" SYNC_SNAPSHOT_RESULT="results.txt" bash ../scripts/script/sync_snapshot.sh
           echo "sync_result=$(cat results.txt)" >> "${GITHUB_OUTPUT}"
+
+      - id: clean_up
+        name: Clean Up
+        working-directory: ${{steps.initialize_instance.outputs.instance}}
+        run: |
+          cd ..
+          rm -Rf ${{steps.initialize_instance.outputs.instance}}
 
   build_github_pages_workflow:
     name: Build Github Pages Workflow
@@ -88,4 +119,6 @@ jobs:
     if: needs.synchronize_snapshot.outputs.sync_result == 'updates'
     uses: ./.github/workflows/gh_pages.yml
     with:
+      debug_mode: ${{ inputs.debug_mode }}
       registry_branch: ${{ inputs.registry_branch }}
+      script_branch: ${{ inputs.script_branch }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ install.json
 install-extras.json
 okapi-install.json
 results.txt
+work

--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@ The [FOLIO](https://folio.org/) module **Module Descriptor Registry** (**MDR**) 
 
 The **MDR** is intended to be accessed directly by [FOLIO](https://folio.org/) instances for determining what module is available to enable.
 
-**MDR** is a simple, static, implementation of the [OKAPI](https://github.com/folio-org/okapi/) module that is hosted on _GitHub Pages_.
+**MDR** is a simple, static, implementation of the [OKAPI](https://github.com/folio-org/okapi/) module that is hosted on **GitHub Pages**.
 Only static Module Descriptor JSON files are served.
 
-The **MDR** _GitHub Pages_ may be found at [https://tamulib.github.io/folio-module-descriptor-registry](https://tamulib.github.io/folio-module-descriptor-registry).
+The **MDR** **GitHub Pages** may be found at [https://tamulib.github.io/folio-module-descriptor-registry](https://tamulib.github.io/folio-module-descriptor-registry).
 
-The Module Descriptors for each release are found within the `release/` subdirectory.
+The Module Descriptors for each release are found within the `release/` sub-directory on a separate branch from the scripts (such as `snapshot`).
+
+The [FOLIO Application Generator](folio-org/folio-application-generator) should be able to utilize this repository if and when it supports the `Simple` mode.
 
 
 ## Scripts
@@ -19,20 +21,48 @@ The Module Descriptors for each release are found within the `release/` subdirec
 This repository provides additional scripts that may help facilitate the generation of the Module Descriptors.
 
 
-## Build Latest
+### Build Latest
 
-The **Build Latest** scripts provides a simple but automated way to create module descriptor symbolic links referencing the latest version.
-This script takes a simple approach of creating a symoblic link to the version specified by the given `install.json` files in the order in which they appear.
+The **Build Latest** script provides a simple but automated way to create module descriptor symbolic links referencing the latest version.
+This script takes a simple approach of creating a symbolic link to the version specified by the given `install.json` files in the order in which they appear.
 
-The order in which the files are passed determines the order (left to right) in which overwrities of existing symbolic links are performed.
-The default behavior is to use the "-latest" in place of the version suffix.
+The order in which the files are passed determines the order (left to right) in which overwrites of existing symbolic links are performed.
+The default behavior is to use the `-latest` in place of the version suffix.
 
 View the documentation within the `build_latest.sh` script for further details on how to operate this script.
 
 Example usage:
 ```shell
+bash script/build_path.sh release/
+```
+
+
+### Build Pages
+
+The **Build Pages** script provides a to generate **GitHub Pages** using a set of very simple templates.
+The templates are provided by default, but custom templates are supported.
+
+The template functionality is not intended to handle complex cases and only utilizes simple logic.
+The basic structure allows for this process to be extensible but such logic is not implemented.
+The `sed` statements in the script will need to be edited to enhance the template options available.
+
+|      Template Variable      | Description
+| --------------------------- | -----------
+| `_REPLACE_LINK_`            | A URI (not intended to have HTML).
+| `_REPLACE_LINK_NAME_`       | A name used for representing a link.
+| `_REPLACE_PAGE_BACK_`       | Used by the script to apply the `back.html` template (explicitly intended to have HTML).
+| `_REPLACE_PAGE_TITLE_`      | A page title, added to the HTML `<HEAD>` (not intended to have HTML).
+| `_REPLACE_SECTION_DATE_`    | A date time stamp to display to users (defaults to a UTC date time).
+| `_REPLACE_SECTION_TITLE_`   | A title to be displayed in HTML.
+| `_REPLACE_SECTION_SNIPPET_` | Used by the script to apply the `item.html` template (explicitly intended to have HTML).
+
+View the documentation within the `build_pages.sh` script for further details on how to operate this script.
+
+Example usage:
+```shell
 BUILD_LATEST_PATH="release/snapshot" bash script/build_latest.sh install.json additional.json
 ```
+
 
 ### Populate Release
 
@@ -73,3 +103,47 @@ Example commit hash usage:
 ```shell
 POPULATE_RELEASE_REPOSITORY_PART="" bash script/populate_release.sh fe7223e040d5d024f3f4961a3bc324d99a6fe7f5 aggies
 ```
+
+
+## GitHub Workflows
+
+This repository utilizes GitHub Workflows to perform Continuous Integration and Continuous Delivery (CI/CD).
+The default configuration relies on `self-hosted` runners.
+_The `self-hosted` runners may easily be changed to something like `ubuntu-latest` and should work, in general._
+
+The GitHub Workflows are expected to clean up their working directory due to the nature of `self-hosted` runners.
+These GitHub Workflows utilize run directories to help reduce potential problems for when running on `self-hosted` runners.
+This does not guarantee parallel safety, but should help make problems significantly less likely.
+The Workflows also attempt to perform clean up on success.
+
+_The `self-hosted` runner is expected to perform its own maintenance to ensure that there are no disk space or other such problems._
+
+These GitHub Workflows support some common input variables.
+These input variables are available both as input variables for event triggers and as input variables if called by other GitHub Workflows.
+
+|      Input Variable     |   Type    | Description
+| ----------------------- | --------- | -----------
+| `debug_mode`            | string    | Enables debugging when non-empty. Special options (space separated): `curl`, `git`, `json`, `verify`, `curl_only`, `git_only`, `json_only`, and `verify_only`.
+| `registry_branch`       | string    | The name of the branch containing the registry descriptor files, such as `snapshot`.
+| `script_branch`         | string    | The name of the branch containing the scripts, such as `master`.
+
+
+### Build GitHub Pages
+
+This GitHub Workflow loads existing, pre-generated, FOLIO module descriptors and deploys the files on the **GitHub Pages** for this repository.
+
+The deployment process utilizes GitHub Artifacts.
+These artifacts may be temporarily downloaded via the GitHub Workflow Action view and are available as per GitHub's retention policies.
+
+
+### Synchronize Snapshot
+
+This GitHub Workflow loads the latest releases from some pre-configured `install.json` file, commits the changes, and pushes the changes to the GitHub repository registry branch.
+Commits made by this Workflow utilize the default GitHub Actions Bot (`41898282+github-actions[bot]@users.noreply.github.com`).
+
+The **Build GitHub Pages Workflow** is automatically called by this GitHub Workflow.
+This only happens if changes are detected.
+Should something go wrong while calling the **Build GitHub Pages Workflow**, then the v must be manually called.
+This is because the changes during the synchronization are committed before the **Build GitHub Pages Workflow** is called.
+
+The **Synchronize Snapshot Workflow** is run using a cron-job like timer every day at 00:00:00 UTC.

--- a/script/build_latest.sh
+++ b/script/build_latest.sh
@@ -58,10 +58,10 @@ build_latest_load_environment() {
     if [[ ${BUILD_LATEST_DEBUG} == "json" ]] ; then
       debug_json="y"
     elif [[ ${BUILD_LATEST_DEBUG} == "json_only" ]] ; then
-      debug=""
+      debug=
       debug_json="y"
     elif [[ $(echo ${BUILD_LATEST_DEBUG} | grep -sho "_only") != "" ]] ; then
-      debug=""
+      debug=
     elif [[ $(echo ${BUILD_LATEST_DEBUG} | grep -sho "\<json\>") != "" ]] ; then
       debug_json="y"
     fi
@@ -142,7 +142,7 @@ build_latest_load_environment() {
 }
 
 build_latest_handle_result() {
-  let result=$?
+  let result=${?}
 
   if [[ ${result} -ne 0 ]] ; then
     echo "${1}"
@@ -192,6 +192,7 @@ build_latest_operate() {
     done
   done
 
+  echo
   echo "Done: Latest versions are built."
 }
 

--- a/script/build_pages.sh
+++ b/script/build_pages.sh
@@ -1,0 +1,412 @@
+#!/bin/bash
+#
+# Build a simple index listing of the descriptors using minimal HTML and script-based templating.
+#
+# This requires the following user-space programs:
+#   - bash
+#   - basename
+#   - cat
+#   - cp
+#   - date
+#   - grep
+#   - jq
+#   - ls
+#   - mkdir
+#   - sed
+#
+#  Parameters:
+#    *) All descriptor source directories to process. This script uses simple logic, be careful about sub-directory naming conflicts.
+#
+#  Environment Variables:
+#    BUILD_PAGES_BASE:           The base URL where the generated pages are stored.
+#    BUILD_PAGES_DEBUG:          Enable debug verbosity, any non-empty string enables this.
+#    BUILD_PAGES_IGNORE_INVALID: Ignore non-JSON files rather than fail, any non-empty string enables this.
+#    BUILD_PAGES_TEMPLATE_BACK:  The name of the back HTML template within the BUILD_PAGES_TEMPLATE_PATH directory.
+#    BUILD_PAGES_TEMPLATE_BASE:  The name of the base HTML template within the BUILD_PAGES_TEMPLATE_PATH directory.
+#    BUILD_PAGES_TEMPLATE_ITEM:  The name of the item HTML template within the BUILD_PAGES_TEMPLATE_PATH directory.
+#    BUILD_PAGES_TEMPLATE_PATH:  The path to the template directory containing the HTML template files.
+#    BUILD_PAGES_WORK:           A working directory used to create the gh-pages structure (all templates and files are added here).
+#
+# The BUILD_PAGES_DEBUG may be specifically set to "json" to include printing the JSON files.
+# The BUILD_PAGES_DEBUG may be specifically set to "json_only" to only print the JSON files, disabling all other debugging (does not pass -v).
+# Otherwise, any non-empty value will result in debug printing without the git command.
+# The BUILD_PAGES_DEBUG may be specifically set to "verify" to include printing the individual verify/process file messages.
+# The BUILD_PAGES_DEBUG may be specifically set to "verify_only" to only print the the individual verify/process file messages, disabling all other debugging (does not pass -v).
+# Otherwise, any non-empty value will result in debug printing without the git command.
+#
+# If any of BUILD_PAGES_TEMPLATE_BASE, BUILD_PAGES_TEMPLATE_ITEM, or BUILD_PAGES_TEMPLATE_PATH are not specified, then the default is loaded for each unspecified variable.
+#
+
+main() {
+  local base="/folio-module-descriptor-registry/"
+  local debug=
+  local debug_json=
+  local debug_verify=
+  local i=
+  local ignore_invalid=
+  local now=$(date -u)
+  local sources=
+  local title_main="Listing of FOLIO Releases"
+  local template_back="back.html"
+  local template_back_data=
+  local template_base="base.html"
+  local template_item="item.html"
+  local template_item_data=
+  local template_path="template/"
+  local work="work/"
+
+  # Custom prefixes for debug and error.
+  local p_d="DEBUG: "
+  local p_e="ERROR: "
+
+  local -i result=0
+
+  build_page_load_environment ${*}
+
+  build_page_operate
+
+  return ${result}
+}
+
+build_page_load_environment() {
+  local file=
+  local parameter=
+  local total=
+
+  if [[ ${BUILD_PAGES_DEBUG} != "" ]] ; then
+    debug="-v"
+
+    if [[ ${BUILD_PAGES_DEBUG} == "json" ]] ; then
+      debug_json="y"
+    elif [[ ${BUILD_PAGES_DEBUG} == "verify" ]] ; then
+      debug_verify="y"
+    elif [[ ${BUILD_PAGES_DEBUG} == "json_only" ]] ; then
+      debug=
+      debug_json="y"
+    elif [[ $(echo ${BUILD_PAGES_DEBUG} | grep -sho "_only") != "" ]] ; then
+      debug=
+    else
+      if [[ $(echo ${BUILD_PAGES_DEBUG} | grep -sho "\<json\>") != "" ]] ; then
+        debug_json="y"
+      fi
+
+      if [[ $(echo ${BUILD_PAGES_DEBUG} | grep -sho "\<verify\>") != "" ]] ; then
+        debug_verify="y"
+      fi
+    fi
+  fi
+
+  # May be empty, so use "-v" test rather than != "".
+  if [[ -v BUILD_PAGES_BASE ]] ; then
+    if [[ $(echo ${BUILD_PAGES_BASE} | sed -e "s|\s||g") == "" ]] ; then
+      base=
+    else
+      base=$(echo ${BUILD_PAGES_BASE} | sed -e 's|/*$|/|g')
+    fi
+  fi
+
+  if [[ ${BUILD_PAGES_IGNORE_INVALID} != "" ]] ; then
+    ignore_invalid="y"
+  fi
+
+  if [[ ${BUILD_PAGES_TEMPLATE_BACK} != "" ]] ; then
+    template_back=$(echo ${BUILD_PAGES_TEMPLATE_BACK} | sed -e 's|//*|/|g' -e 's|/*$||g')
+  fi
+
+  if [[ ${BUILD_PAGES_TEMPLATE_BASE} != "" ]] ; then
+    template_base=$(echo ${BUILD_PAGES_TEMPLATE_BASE} | sed -e 's|//*|/|g' -e 's|/*$||g')
+  fi
+
+  if [[ ${BUILD_PAGES_TEMPLATE_ITEM} != "" ]] ; then
+    template_item=$(echo ${BUILD_PAGES_TEMPLATE_ITEM} | sed -e 's|//*|/|g' -e 's|/*$||g')
+  fi
+
+  if [[ ${BUILD_PAGES_TEMPLATE_PATH} != "" ]] ; then
+    template_path=$(echo ${BUILD_PAGES_TEMPLATE_PATH} | sed -e 's|//*|/|g' -e 's|/*$|/|g')
+  fi
+
+  if [[ ! -d ${template_path} ]] ; then
+    echo "${p_e}The following path is not a valid template directory: ${template_path} ."
+
+    let result=1
+  else
+    if [[ ! -f ${template_path}${template_back} ]] ; then
+      echo "${p_e}The following path is not a valid back template file: ${template_path}${template_back} ."
+
+      let result=1
+    fi
+
+    if [[ ! -f ${template_path}${template_base} ]] ; then
+      echo "${p_e}The following path is not a valid base template file: ${template_path}${template_base} ."
+
+      let result=1
+    fi
+
+    if [[ ! -f ${template_path}${template_item} ]] ; then
+      echo "${p_e}The following path is not a valid item template file: ${template_path}${template_item} ."
+
+      let result=1
+    fi
+  fi
+
+  if [[ ${BUILD_PAGES_WORK} != "" ]] ; then
+    work=$(echo ${BUILD_PAGES_WORK} | sed -e 's|//*|/|g' -e 's|/*$|/|g')
+  fi
+
+  if [[ -e ${work} && ! -d ${work} ]] ; then
+    echo "${p_e}The following path is not a valid work directory: ${work} ."
+
+    let result=1
+  fi
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  template_back_data=$(cat ${template_path}${template_back})
+  template_item_data=$(cat ${template_path}${template_item})
+
+  if [[ ! -d ${work} ]] ; then
+    mkdir ${debug} -p ${work}
+
+    build_page_handle_result "Failed to create work directory: ${work}"
+  fi
+
+  if [[ ${result} -eq 0 && ${#} -gt 0 ]] ; then
+    total=${#}
+
+    while [[ ${i} -lt ${total} ]] ; do
+      let i=${i}+1
+      parameter=${!i}
+
+      file=$(echo ${parameter} | sed -e 's|//*|/|' -e 's|/*$|/|')
+
+      if [[ ! -d ${file} ]] ; then
+        echo "${p_e}The following path is not a valid descriptor source directory: ${file} ."
+
+        let result=1
+
+        return
+      fi
+
+      sources="${sources}${file} "
+    done
+  fi
+}
+
+build_page_handle_result() {
+  let result=${?}
+
+  if [[ ${result} -ne 0 ]] ; then
+    echo "${1}"
+  fi
+}
+
+build_page_operate() {
+  local indexes=
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  build_page_operate_sources
+
+  build_page_operate_sources_process_index "${work}/index.html" "${title_main}" "${indexes}"
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  echo
+  echo "Done: Pages are built."
+}
+
+build_page_operate_sources() {
+  local source=
+  local j=
+  local k=
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  for i in ${sources} ; do
+
+    echo
+    echo "Operating on source: ${i} ."
+
+    if [[ $(ls ${i}) != "" ]] ; then
+      for j in ${i}* ; do
+        source=$(basename ${j})
+
+        build_page_operate_sources_process_index_template_item
+
+        echo
+        echo "Operating on source ${i} work source sub-directory: ${source} ."
+
+        mkdir ${debug} -p ${work}${source}
+
+        build_page_handle_result "Failed to create work source sub-directory: ${work}${source}"
+
+        if [[ ${result} -ne 0 ]] ; then break ; fi
+        if [[ $(ls ${j}/) == "" ]] ; then continue ; fi
+
+        build_page_operate_sources_process_files
+
+        if [[ ${result} -ne 0 ]] ; then break ; fi
+      done
+    fi
+
+    if [[ ${result} -ne 0 ]] ; then break ; fi
+  done
+}
+
+build_page_operate_sources_process_files() {
+  local file=
+  local files=
+  local items=
+  local k=
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  for k in ${j}/* ; do
+    file=$(basename ${k})
+
+    if [[ $(echo -n ${file} | grep -sho "^\.") != "" ]] ; then
+      build_page_print_debug_verify "Skipping work source sub-directory ${source} hidden file: ${file}"
+
+      continue
+    fi
+
+    if [[ -d ${k} ]] ; then
+      build_page_print_debug_verify "Skipping work source sub-directory ${source} directory file: ${file}"
+
+      continue
+    fi
+
+    build_page_print_debug_verify "Verifying work source sub-directory ${source} file: ${file}"
+
+    if [[ ! -f ${k} ]] ; then
+      let result=1
+    fi
+
+    build_page_operate_sources_process_files_verify_file
+
+    build_page_operate_sources_process_files_copy_file
+
+    build_page_operate_sources_process_files_template_item "${source}/${file}" "${file}"
+
+    # Reset error for each loop pass, the problems represents the final error state.
+    if [[ ${result} -ne 0 ]] ; then
+      problems="${problems}${k} "
+
+      let result=0
+    fi
+  done
+
+  if [[ ${problems} != "" ]] ; then
+    echo "${p_e}Build Path failed, the following files are missing, invalid, or failed to be processed: ${problems}."
+
+    let result=1
+  fi
+
+  build_page_operate_sources_process_index "${work}${source}/index.html" "Listing of ${source} Release" "${items}" yes
+}
+
+build_page_operate_sources_process_files_copy_file() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  cp ${debug} ${k} ${work}${source}/${file}
+
+  build_page_handle_result "Failed to copy ${k} to ${work}${source}/${file}"
+}
+
+build_page_operate_sources_process_files_template_item() {
+  local item=
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  item=$(echo ${template_item_data} | sed -e "s|\<_REPLACE_LINK_\>|${source}/${file}|g" -e "s|\<_REPLACE_LINK_NAME_\>|${file}|g")
+  items="${items}${item}_REPLACE_EOL_ "
+}
+
+build_page_operate_sources_process_files_verify_file() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  # Prevent jq from printing JSON if /dev/null exists when not debugging.
+  if [[ ${debug_json} != "" || ! -e /dev/null ]] ; then
+    cat ${k} | jq
+  else
+    cat ${k} | jq >> /dev/null
+  fi
+
+  let result=${?}
+
+  if [[ ${result} -ne 0 ]] ; then
+    if [[ ${ignore_invalid} != "" ]] ; then
+      build_page_print_debug "Ignoring work source sub-directory ${source} invalid JSON file: ${file}"
+
+      let result=0
+    fi
+  fi
+}
+
+build_page_operate_sources_process_index() {
+  local index=${1}
+  local title=${2}
+  local snippet=${3}
+  local back=${4}
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  if [[ $(echo ${snippet} | sed -e "s|\s||g") == "" ]] ; then
+    snippet="There are no items available."
+  fi
+
+  if [[ ${back} != "" ]] ; then
+    if [[ $(echo ${template_back_data} | sed -e "s|\s||g") == "" ]] ; then
+      back=
+    else
+      back=$(echo ${template_back_data} | sed -e "s|\<_REPLACE_LINK_\>||g" -e "s|\<_REPLACE_SECTION_TITLE_\>|${title_main}|g")
+    fi
+  fi
+
+  cp ${debug} ${template_path}${template_base} ${index}
+
+  build_page_handle_result "Failed to copy ${template_path}${template_item} to ${index}"
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  sed -i \
+    -e "s|\<_REPLACE_BASE_PATH_\>|${base}|g" \
+    -e "s|\<_REPLACE_PAGE_BACK_\>|${back}|g" \
+    -e "s|\<_REPLACE_PAGE_TITLE_\>|${title}|g" \
+    -e "s|\<_REPLACE_SECTION_TITLE_\>|${title}|g" \
+    -e "s|\<_REPLACE_SECTION_DATE_\>|${now}|g" \
+    -e "s|\<_REPLACE_SECTION_SNIPPET_\>|${snippet}|g" \
+    -e "s|\s*\<_REPLACE_EOL_\>\s*|\n|g" \
+    ${index}
+
+  build_page_handle_result "Failed to expand template variables in ${index}"
+}
+
+build_page_operate_sources_process_index_template_item() {
+  local item=
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  item=$(echo ${template_item_data} | sed -e "s|\<_REPLACE_LINK_\>|${source}/|g" -e "s|\<_REPLACE_LINK_NAME_\>|${source}|g")
+  indexes="${indexes}${item}_REPLACE_EOL_ "
+}
+
+build_page_print_debug() {
+
+  if [[ ${debug} == "" ]] ; then return ; fi
+
+  echo "${p_d}${1} ."
+  echo
+}
+
+build_page_print_debug_verify() {
+
+  if [[ ${debug_verify} == "" ]] ; then return ; fi
+
+  echo
+  echo "${p_d}${1} ."
+}
+
+main ${*}

--- a/script/populate_release.sh
+++ b/script/populate_release.sh
@@ -134,15 +134,15 @@ pop_rel_load_environment() {
 
   if [[ ${POPULATE_RELEASE_DEBUG} != "" ]] ; then
     debug="-v"
-    debug_curl=""
+    debug_curl=
 
     if [[ ${POPULATE_RELEASE_DEBUG} == "curl" ]] ; then
       debug_curl="y"
     elif [[ ${POPULATE_RELEASE_DEBUG} == "curl_only" ]] ; then
-      debug=""
+      debug=
       debug_curl="y"
     elif [[ $(echo ${POPULATE_RELEASE_DEBUG} | grep -sho "_only") != "" ]] ; then
-      debug=""
+      debug=
     elif [[ $(echo ${POPULATE_RELEASE_DEBUG} | grep -sho "\<curl\>") != "" ]] ; then
       debug_curl="y"
     fi
@@ -235,7 +235,7 @@ pop_rel_print_curl_debug() {
 }
 
 pop_rel_handle_result() {
-  let result=$?
+  let result=${?}
 
   if [[ ${result} -ne 0 ]] ; then
     echo "${1}"

--- a/script/sync_snapshot.sh
+++ b/script/sync_snapshot.sh
@@ -52,8 +52,10 @@ main() {
   if [[ ${result} -ne 0 ]] ; then
     updated="failure"
   elif [[ ${updated} == "none" ]] ; then
+    echo
     echo "Done: No changes to commit detected."
   else
+    echo
     echo "Done: Pushed detected changes."
   fi
 
@@ -106,7 +108,7 @@ sync_snap_push() {
 }
 
 sync_snap_handle_result() {
-  let result=$?
+  let result=${?}
 
   if [[ ${result} -ne 0 ]] ; then
     echo "${1}"
@@ -114,7 +116,7 @@ sync_snap_handle_result() {
 }
 
 sync_snap_handle_result_git() {
-  let result=$?
+  let result=${?}
 
   if [[ ${result} -ne 0 ]] ; then
     echo "${p_e}Git failed (with system code ${result}) when ${1} changes."
@@ -133,10 +135,10 @@ sync_snap_load_environment() {
     if [[ ${SYNC_SNAPSHOT_DEBUG} == "git" ]] ; then
       debug_git="y"
     elif [[ ${SYNC_SNAPSHOT_DEBUG} == "git_only" ]] ; then
-      debug=""
+      debug=
       debug_git="y"
     elif [[ $(echo ${SYNC_SNAPSHOT_DEBUG} | grep -sho "_only") != "" ]] ; then
-      debug=""
+      debug=
     elif [[ $(echo ${SYNC_SNAPSHOT_DEBUG} | grep -sho "\<git\>") != "" ]] ; then
       debug_git="y"
     fi

--- a/template/back.html
+++ b/template/back.html
@@ -1,0 +1,1 @@
+<div><p><a href="_REPLACE_LINK_">Back to _REPLACE_SECTION_TITLE_</a></p></div>

--- a/template/base.html
+++ b/template/base.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>_REPLACE_PAGE_TITLE_</title>
+    <base href="_REPLACE_BASE_PATH_">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>_REPLACE_SECTION_TITLE_</h1>
+      </header>
+      <div>
+        <p>
+          This page has been generated on _REPLACE_SECTION_DATE_.
+        </p>
+      </div>
+      _REPLACE_PAGE_BACK_
+      <div>
+        <ol>
+          _REPLACE_SECTION_SNIPPET_
+        </ol>
+      </div>
+    </main>
+  </body>
+</html>

--- a/template/item.html
+++ b/template/item.html
@@ -1,0 +1,1 @@
+<li><a href="_REPLACE_LINK_">_REPLACE_LINK_NAME_</a></li>


### PR DESCRIPTION
The primary purpose of this change is to add a GitHub Pages generator. The previous one being used required Docker and also did not work correctly within our `self-hosted` runner for unknown reasons. This new script provides more fine-tuned control over how and what is generated.

The GitHub Pages generator is a collection of two parts:
  1. A GitHub Workflow called `gh_pages.yml`.
  2. A Bash script called `build_pages.sh`.

The `gh_pages.yml` Workflow already exists and is modified to utilize the new script, `build_pages.sh`.

All GitHub Workflows have been updated as follows:
  - Improve readability by adding a new line between each run step.
  - Add an Initialize Instance step to improve parallel execution safety in a `self-hosted` runner.
  - Create the working directories at the start and then delete the working directories on success at the end.
  - Have an `id` for each step.
  - Operate each step within the more parallel safe sub-directory.
  - Support the `debug_mode` input variable to allow toggling debug modes for each individual run.
  - Put the inputs in alphabetic mode, except `debug_mode` in the specific case of displaying it as a form input in the GitHub Actions interface.

The `sync_snapshot.yml` Workflow now properly includes the `setting` directory in the sparse checkout. This was missing before and is essentially a bug.
This was not noticed before because the `settings/ignore.txt` file is currently empty.

Make sure to have git ignore the `work` directory that is now used by the `build_pages.sh` script.

Update the `README.md` as follows:
  - Make GitHub Pages link bold.
  - Add details about the FOLIO Application Generator.
  - Fix heading ordering problem.
  - Add missing example usage for the Build Latest Readme documentation.
  - Add GitHub Workflows Readme documentation, briefly describing each GitHub Workflow.
  - Add Build Pages script documentation to the Readme.

Make scripts more consistent:
  - Don't assign variable to empty using quotes like `debug=""` because assigning empty works like `debug=`.
  - Try to be consistent by wrapping variables in braces `{`, `}` (this is not strictly required in some cases but it helps make the script more compatible with different shells beyond Bash).
  - Print extra new line before the "Done" messages to help make it easier to find in the logs.

Add the `build_pages.sh` script.
See the readme and script documentation for details. This requires several programs to exist on the runner:
  - bash
  - basename
  - cat
  - cp
  - date
  - grep
  - jq
  - ls
  - mkdir
  - sed

The script is designed with the intention that there might be multiple directories to use. However, it is not currently designed to handle name conflicts between multiple directories and their respective content.

This script is (and actually all scripts in this repository) are designed to be also run manually on someones local box if they are able. The following is an example that shows how to build locally and use a local browser to (note some systems need `file://///` instead of `file:///`) view:
```shell
BUILD_PAGES_DEBUG="" BUILD_PAGES_BASE="file:///somewhere" bash script/build_pages.sh release/
```

This script is designed to generate the most simplistic of pages without JavaScript, CSS, or images. An ordered list is used to help users find or communicate any given line.

A very basic templating system is used to allow for minor customizations. This templating system also helps keep the HTML out of the script. The template using very basic regex pattern matching on word boundaries.