### PR TITLE
Add support for Euerka Platform install, add POPULATE_RELEASE_CURL_FAIL, and update gh_pages Workflow.

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -1,5 +1,5 @@
 name: Build Github Pages
-run-name: Build Github Pages using registry branch ${{ inputs.registry_branch }} by @${{ github.actor }}
+run-name: Build Github Pages using script branch ${{ inputs.script_branch }} and registry branch ${{ inputs.registry_branch }} by @${{ github.actor }}
 
 on:
   push:

--- a/.github/workflows/sync_snapshot.yml
+++ b/.github/workflows/sync_snapshot.yml
@@ -95,7 +95,7 @@ jobs:
         name: Build Latest Version Links
         working-directory: ${{steps.initialize_instance.outputs.instance}}/populate
         run: |
-          BUILD_LATEST_DEBUG="${{ inputs.debug_mode }}" BUILD_LATEST_IGNORE=../scripts/setting/ignore.txt BUILD_LATEST_PATH=release/snapshot bash ../scripts/script/build_latest.sh
+          BUILD_LATEST_DEBUG="${{ inputs.debug_mode }}" BUILD_LATEST_IGNORE="../scripts/setting/ignore.txt" bash ../scripts/script/build_latest.sh
 
       - id: synchronize_snapshot
         name: Synchronize Snapshot

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+eureka-platform.json
 install.json
 install-extras.json
 okapi-install.json

--- a/script/build_latest.sh
+++ b/script/build_latest.sh
@@ -147,6 +147,7 @@ build_latest_handle_result() {
 
   if [[ ${result} -ne 0 ]] ; then
     echo "${1}"
+    echo
   fi
 }
 

--- a/script/populate_release.sh
+++ b/script/populate_release.sh
@@ -14,6 +14,7 @@
 #    2) (optional) The Flower release name, such as "quesnelia" or "snapshot", used to create the destination directory.
 #
 #  Environment Variables:
+#    POPULATE_RELEASE_CURL_FAIL:       Designate how to handle curl failures. This can be one of: "fail", "none", and "report" (default).
 #    POPULATE_RELEASE_DEBUG:           Enable debug verbosity, any non-empty string enables this.
 #    POPULATE_RELEASE_DESTINATION:     Destination parent directory.
 #    POPULATE_RELEASE_FILE_REUSE:      Enable re-using existing JSON files without GET fetching, any non-empty string enables this.
@@ -33,18 +34,31 @@
 # The POPULATE_RELEASE_DEBUG may be specifically set to "curl_only" to only print the curl commands, disabling all other debugging (does not pass -v to curl).
 # Otherwise, any non-empty value will result in debug printing without the curl command.
 #
+# The POPULATE_RELEASE_CURL_FAIL designate the fail mode of either "fail" or "continue".
+#
+# When the fail mode is "fail", then the "--fail" parameter is passed to curl.
+# This should result in a failure on 404.
+#
+# When the fail mode is "none", then the "--fail" parameter is not passed to curl.
+# This can result in bad data in the release files (non JSON data) on any 4xx error, such as a 404.
+#
+# When the fail mode is "report", then the "--fail" parameter is passed to curl, but the errors are printed and the script continues to operate, ignoring the failure.
+# There should be no release file created.
+#
 
 main() {
   local debug=
   local debug_curl=
-  local registry="https://folio-registry.dev.folio.org/_/proxy/modules/"
   local destination="release/"
+  local curl_fail="--fail"
+  local fail_mode="report"
   local files="install.json eureka-platform.json"
-  local part="heads"
-  local target="snapshot"
   local flower="snapshot"
-  local repository="https://raw.githubusercontent.com/folio-org/platform-complete/"
+  local part="heads"
+  local registry="https://folio-registry.dev.folio.org/_/proxy/modules/"
   local releases=
+  local repository="https://raw.githubusercontent.com/folio-org/platform-complete/"
+  local target="snapshot"
 
   # Custom prefixes for debug and error.
   local p_d="DEBUG: "
@@ -94,6 +108,25 @@ pop_rel_load_environment() {
       debug=
     elif [[ $(echo ${POPULATE_RELEASE_DEBUG} | grep -sho "\<curl\>") != "" ]] ; then
       debug_curl="y"
+    fi
+  fi
+
+  if [[ ${POPULATE_RELEASE_CURL_FAIL} != "" ]] ; then
+    if [[ ${POPULATE_RELEASE_CURL_FAIL} == "fail" ]] ; then
+      curl_fail="--fail"
+      fail_mode="fail"
+    elif [[ ${POPULATE_RELEASE_CURL_FAIL} == "none" ]] ; then
+      curl_fail=
+      fail_mode="none"
+    elif [[ ${POPULATE_RELEASE_CURL_FAIL} == "report" ]] ; then
+      curl_fail="--fail"
+      fail_mode="report"
+    else
+      echo "${p_e}Unknown POPULATE_RELEASE_CURL_FAIL value: ${POPULATE_RELEASE_CURL_FAIL} ."
+
+      let result=1
+
+      return
     fi
   fi
 
@@ -220,11 +253,18 @@ pop_rel_process_files_releases_curl() {
       echo "Curl requesting Module Descriptor: ${i}."
     fi
 
-    pop_rel_print_curl_debug "Executing Descriptor" "curl -w '\n' ${debug} ${registry}${i} -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'cache-control: no-cache' -o ${destination}${flower}/${i}"
+    pop_rel_print_curl_debug "Executing Descriptor" "curl -w '\n' ${curl_fail} ${debug} ${registry}${i} -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'cache-control: no-cache' -o ${destination}${flower}/${i}"
 
-    curl -w '\n' ${debug} ${registry}${i} -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'cache-control: no-cache' -o ${destination}${flower}/${i}
+    curl -w '\n' ${curl_fail} ${debug} ${registry}${i} -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'cache-control: no-cache' -o ${destination}${flower}/${i}
 
-    pop_rel_handle_result "${p_e}Curl request failed (with system code ${result}) for: ${registry}${i} to ${destination}${flower}/${i}."
+    pop_rel_handle_result "${p_e}Curl request failed (with system code ${?}) for: ${registry}${i} to ${destination}${flower}/${i}."
+
+    if [[ ${result} -ne 0 && ${fail_mode} == "report" ]] ; then
+      # A 404 results in a 22 status code returned.
+      if [[ ${result} -eq 22 ]] ; then
+        let result=0
+      fi
+    fi
 
     if [[ ${result} -ne 0 ]] ; then return ; fi
   done
@@ -243,7 +283,7 @@ pop_rel_process_files_releases_prepare() {
   if [[ ! -d ${destination}${flower}/ ]] ; then
     mkdir ${debug} -p ${destination}${flower}/
 
-    pop_rel_handle_result "${p_e}Create directory failed (with system code ${result}) for destination: ${destination}${flower}/ ."
+    pop_rel_handle_result "${p_e}Create directory failed (with system code ${?}) for destination: ${destination}${flower}/ ."
   fi
 }
 
@@ -279,7 +319,7 @@ pop_rel_process_sources_prepare() {
   if [[ -e ${file} ]] ; then
     rm ${debug} -f ${file}
 
-    pop_rel_handle_result "${p_e}Create file failed (with system code ${result}) for install file: ${file} ."
+    pop_rel_handle_result "${p_e}Create file failed (with system code ${?}) for install file: ${file} ."
   fi
 }
 
@@ -287,11 +327,11 @@ pop_rel_process_sources_curl() {
 
   if [[ ${result} -ne 0 ]] ; then return ; fi
 
-  pop_rel_print_curl_debug "Executing Package" "curl -w '\n' ${debug} ${source} -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'cache-control: no-cache' -o ${file}"
+  pop_rel_print_curl_debug "Executing Package" "curl -w '\n' ${curl_fail} ${debug} ${source} -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'cache-control: no-cache' -o ${file}"
 
-  curl -w '\n' ${debug} ${source} -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'cache-control: no-cache' -o ${file}
+  curl -w '\n' ${curl_fail} ${debug} ${source} -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'cache-control: no-cache' -o ${file}
 
-  pop_rel_handle_result "${p_e}Curl request failed (with system code ${result}) for: ${source} ."
+  pop_rel_handle_result "${p_e}Curl request failed (with system code ${?}) for: ${source} ."
 }
 
 pop_rel_handle_result() {
@@ -299,6 +339,7 @@ pop_rel_handle_result() {
 
   if [[ ${result} -ne 0 ]] ; then
     echo "${1}"
+    echo
   fi
 }
 

--- a/script/sync_snapshot.sh
+++ b/script/sync_snapshot.sh
@@ -112,6 +112,7 @@ sync_snap_handle_result() {
 
   if [[ ${result} -ne 0 ]] ; then
     echo "${1}"
+    echo
   fi
 }
 
@@ -161,7 +162,7 @@ sync_snap_load_environment() {
   if [[ ${path} != "" ]] ; then
     cd ${path}
 
-    sync_snap_handle_result "${p_e}Failed (with system code ${result}) to change to path: ${path} ."
+    sync_snap_handle_result "${p_e}Failed (with system code ${?}) to change to path: ${path} ."
   fi
 }
 


### PR DESCRIPTION
### Euerka Platform
The `eureka-platform.json` contains additional files that needs to be part of the snapshot releases.

The `populate_release.sh` script has the following changes:
  - Now supports multiple files, just like the `build_latest.sh` script is designed.
  - Includes `eureka-platform.json` by default.
  - Rename functions to be more consistent with the new program flow due to looping over multiple JSON files.
  - Fix mistake in debug logging where the wrong curl message is printed.

There are several changes to the `build_latest.sh` script:
  - Now has `release/snapshot/` as a default path.
  - Now provides the files by default and clears the `files` variable only when parameters are passed.
  - Fix spelling mistake with the word "sensitive".
  - Improve the multiple file loading logic (there are mistakes in the previous logic).
  - Improve path sanitization.
  - Improve debug information when processing the files.

The `.gitignore` file now ignores the `eureka-platform.json` file.

### POPULATE_RELEASE_CURL_FAIL

The `curl` command does not return a failing state by default when a `404` is received.
Change the setup to pass `--fail` to `curl`, provide custom handling, and make this configurable via `POPULATE_RELEASE_CURL_FAIL`.

The `--fail` mode is called "fail fast" and a `22` is returned as the status code.
This does not catch all cases, so the script is designed to make room for multiple codes to be added in the future if need be.

There are three modes for `POPULATE_RELEASE_CURL_FAIL`.
  1. `fail`: When curl fails with `--fail` passed, then exit the script on error.
  2. `none`: The default curl behavior is performed. A `404` does not trigger a failure and data is downloaded, even if that data is invalid.
  3. `report`: When curl fails with `--fail` and a `22` status is returned, then report the failure but continue running the script (no files are downloaded).

The default is set to `report`.
This is done because there are several FOLIO modules defined that currently return `404`.
These modules may not be needed at this time.
Known problems at this time are:
  - `folio-module-sidecar-2.1.0-SNAPSHOT.172`
  - `mgr-applications-3.1.0-SNAPSHOT.149`
  - `mgr-tenant-entitlements-3.1.0-SNAPSHOT.177`
  - `mgr-tenants-3.1.0-SNAPSHOT.120`

The output gets a little messy when `report` mode is used.
Print a new line after each handle result print call.
Make this change across all scripts for consistency reasons.

The "with system code" error messages are now containing the actual error code.
This change is applied across all scripts for consistency reasons.

### gh_pages Workflow
Display script branch in GitHub Action for gh_pages Workflow.

This makes the display consistent with the `sync_snapshot` Workflow.