### PR TITLE
Prevent missing files from blocking remaining processes for build_latest.sh.

### DIFF
--- a/.github/workflows/sync_snapshot.yml
+++ b/.github/workflows/sync_snapshot.yml
@@ -95,7 +95,7 @@ jobs:
         name: Build Latest Version Links
         working-directory: ${{steps.initialize_instance.outputs.instance}}/populate
         run: |
-          BUILD_LATEST_DEBUG="${{ inputs.debug_mode }}" BUILD_LATEST_IGNORE="../scripts/setting/ignore.txt" bash ../scripts/script/build_latest.sh
+          BUILD_LATEST_DEBUG="${{ inputs.debug_mode }}" BUILD_LATEST_IGNORE="../scripts/setting/ignore.txt" BUILD_LATEST_SKIP_NOT_FOUND="y" bash ../scripts/script/build_latest.sh
 
       - id: synchronize_snapshot
         name: Synchronize Snapshot

--- a/script/build_latest.sh
+++ b/script/build_latest.sh
@@ -13,10 +13,11 @@
 #    *) A list of install.json file names to parse (order sensitive).
 #
 #  Environment Variables:
-#    BUILD_LATEST_DEBUG:  Enable debug verbosity, any non-empty string enables this.
-#    BUILD_LATEST_FILES:  A list of files to build (applied before the command line arguments).
-#    BUILD_LATEST_IGNORE: A path to a space and new line separated file (such as "setting/ignore.txt") representing module names to ignore.
-#    BUILD_LATEST_PATH:   The destination path to write to.
+#    BUILD_LATEST_DEBUG:          Enable debug verbosity, any non-empty string enables this.
+#    BUILD_LATEST_FILES:          A list of files to build (applied before the command line arguments).
+#    BUILD_LATEST_IGNORE:         A path to a space and new line separated file (such as "setting/ignore.txt") representing module names to ignore.
+#    BUILD_LATEST_PATH:           The destination path to write to.
+#    BUILD_LATEST_SKIP_NOT_FOUND: Skip version files that are not found, any non-empty string enables this.
 #
 # The BUILD_LATEST_DEBUG may be specifically set to "json" to include printing the JSON files.
 # The BUILD_LATEST_DEBUG may be specifically set to "json_only" to only print the JSON files, disabling all other debugging (does not pass -v).
@@ -37,6 +38,7 @@ main() {
   local p_e="ERROR: "
 
   local -i result=0
+  local -i skip_not_found=0
 
   build_latest_load_environment ${*}
 
@@ -104,6 +106,10 @@ build_latest_load_environment() {
 
       file=
     fi
+  fi
+
+  if [[ ${BUILD_LATEST_SKIP_NOT_FOUND} != "" ]] ; then
+    let skip_not_found=1
   fi
 
   # Load files from the command line parameters.
@@ -180,6 +186,12 @@ build_latest_operate() {
       fi
 
       if [[ ! -f ${path}${i} ]] ; then
+        if [[ ${skip_not_found} -ne 0 ]] ; then
+          build_latest_print_debug "Cannot find the version file in ${file} for ${release} to link against, skipping file: ${path}${i}"
+
+          continue
+        fi
+
         echo "${p_e}Cannot find the version file in ${file} for ${release} to link to: ${path}${i} ."
 
         let result=1

--- a/script/populate_release.sh
+++ b/script/populate_release.sh
@@ -205,6 +205,9 @@ pop_rel_process_files() {
   for i in ${files} ; do
     file=${i}
 
+    echo
+    echo "Operating on ${file}."
+
     pop_rel_load_source
 
     pop_rel_process_files_releases_prepare


### PR DESCRIPTION
The `build_latest.sh` script is failing because of:
```
ERROR: Cannot find the version file in eureka-platform.json for folio-module-sidecar to link to: release/snapshot/folio-module-sidecar-3.1.0-SNAPSHOT.176 .
```

This module is not fetchable at this time using the upstream registry.

Add an option, `BUILD_LATEST_SKIP_NOT_FOUND`, to just skip when the file is missing rather than completely fail. This allows for the everything else that has been fetched to still be published to the registry. The skipped modules can be later investigated.

The `populate_release.sh` script is printing the curl progress logs by default but the individual file being processed is not printed. Print a message about the file.
This should help when debugging cases for why `build_latest.sh` failed.