### PR TITLE
Add Populate Node script and minor changes in scripts and workflows.

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -1,5 +1,5 @@
 name: Build Github Pages
-run-name: Build Github Pages using script branch ${{ inputs.script_branch }} and registry branch ${{ inputs.registry_branch }} by @${{ github.actor }}
+run-name: Build Github Pages using script branch '${{ inputs.script_branch }}' and registry branch '${{ inputs.registry_branch }}' by @${{ github.actor }}
 
 on:
   push:
@@ -86,7 +86,10 @@ jobs:
       - name: Generate Directory Listings
         working-directory: ${{steps.initialize_instance.outputs.instance}}/populate
         run: |
-          BUILD_PAGES_DEBUG="${{ inputs.debug_mode }}" BUILD_PAGES_WORK="../work" BUILD_PAGES_TEMPLATE_PATH="../scripts/template" bash ../scripts/script/build_pages.sh release/
+          BUILD_PAGES_DEBUG="${{ inputs.debug_mode }}" \
+          BUILD_PAGES_WORK="../work" \
+          BUILD_PAGES_TEMPLATE_PATH="../scripts/template" \
+            bash ../scripts/script/build_pages.sh release/
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/sync_snapshot.yml
+++ b/.github/workflows/sync_snapshot.yml
@@ -1,5 +1,5 @@
 name: Synchronize Snapshot
-run-name: Synchronize Snapshot using script branch ${{ inputs.script_branch }} and registry branch ${{ inputs.registry_branch }} by @${{ github.actor }}
+run-name: Synchronize Snapshot using script branch '${{ inputs.script_branch }}' and registry branch '${{ inputs.registry_branch }}' by @${{ github.actor }}
 
 on:
   schedule:
@@ -50,6 +50,7 @@ jobs:
 
     outputs:
       instance: ${{ steps.initialize_instance.outputs.instance }} # Help make parallel execution safer.
+      top_dir: ${{ steps.initialize_instance.outputs.top_dir }}
       sync_result: ${{ steps.synchronize_snapshot.outputs.sync_result }}
 
     runs-on: self-hosted
@@ -60,12 +61,19 @@ jobs:
           export THIS_INSTANCE="run_${RANDOM}"
           echo "Running with instance: ${THIS_INSTANCE}"
           echo "instance=${THIS_INSTANCE}" >> "${GITHUB_OUTPUT}"
+          echo "top_dir=${PWD}/" >> "${GITHUB_OUTPUT}"
 
       - id: create_dirs
         name: Clean and Create Working Directories
         run: |
           rm -Rf ${{steps.initialize_instance.outputs.instance}}/{populate,scripts}
           mkdir -p ${{steps.initialize_instance.outputs.instance}}/{populate,scripts}
+
+      - id: assure_stripes
+        name: Assure Stripes
+        run: |
+          if [[ $(type -p stripes) == "" ]] ; then yarn config set @folio:registry https://repository.folio.org/repository/npm-folioci/ ; fi
+          if [[ $(type -p stripes) == "" ]] ; then yarn global add @folio/stripes-cli ; fi
 
       - id: checkout_registry
         name: Checkout Registry
@@ -81,21 +89,38 @@ jobs:
           ref: ${{ inputs.script_branch }}
           path: ${{steps.initialize_instance.outputs.instance}}/scripts
           sparse-checkout: |
+            script/populate_node.sh
             script/populate_release.sh
             script/sync_snapshot.sh
             setting
+            workspace
 
-      - id: populate_snapshot
-        name: Populate Snapshot
+      - id: populate_release
+        name: Populate Release
         working-directory: ${{steps.initialize_instance.outputs.instance}}/populate
         run: |
-          POPULATE_RELEASE_DEBUG="${{ inputs.debug_mode }}" bash ../scripts/script/populate_release.sh
+          POPULATE_RELEASE_DEBUG="${{ inputs.debug_mode }}" \
+            bash ../scripts/script/populate_release.sh
+
+      - id: populate_node
+        name: Populate Node
+        working-directory: ${{steps.initialize_instance.outputs.instance}}/populate
+        run: |
+          POPULATE_NODE_DEBUG="${{ inputs.debug_mode }}" \
+          POPULATE_NODE_DESTINATION="${{ steps.initialize_instance.outputs.top_dir }}${{steps.initialize_instance.outputs.instance}}/populate/release/snapshot/" \
+          POPULATE_NODE_NPM_DIR="${{ steps.initialize_instance.outputs.top_dir }}${{steps.initialize_instance.outputs.instance}}/populate/" \
+          POPULATE_NODE_SKIP_BAD="y" \
+          POPULATE_NODE_WORKSPACE="${{ steps.initialize_instance.outputs.top_dir }}${{steps.initialize_instance.outputs.instance}}/scripts/workspace" \
+            bash ../scripts/script/populate_node.sh
 
       - id: build_latest
         name: Build Latest Version Links
         working-directory: ${{steps.initialize_instance.outputs.instance}}/populate
         run: |
-          BUILD_LATEST_DEBUG="${{ inputs.debug_mode }}" BUILD_LATEST_IGNORE="../scripts/setting/ignore.txt" BUILD_LATEST_SKIP_NOT_FOUND="y" bash ../scripts/script/build_latest.sh
+          BUILD_LATEST_DEBUG="${{ inputs.debug_mode }}" \
+          BUILD_LATEST_IGNORE="../scripts/setting/ignore.txt" \
+          BUILD_LATEST_SKIP_NOT_FOUND="y" \
+            bash ../scripts/script/build_latest.sh
 
       - id: synchronize_snapshot
         name: Synchronize Snapshot
@@ -103,7 +128,9 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          SYNC_SNAPSHOT_DEBUG="${{ inputs.debug_mode }}" SYNC_SNAPSHOT_RESULT="results.txt" bash ../scripts/script/sync_snapshot.sh
+          SYNC_SNAPSHOT_DEBUG="${{ inputs.debug_mode }}" \
+          SYNC_SNAPSHOT_RESULT="results.txt" \
+            bash ../scripts/script/sync_snapshot.sh
           echo "sync_result=$(cat results.txt)" >> "${GITHUB_OUTPUT}"
 
       - id: clean_up

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 eureka-platform.json
 install.json
 install-extras.json
+npm.json
 okapi-install.json
 results.txt
 work
+workspace/node_modules
+workspace/yarn.lock

--- a/README.md
+++ b/README.md
@@ -86,6 +86,26 @@ bash script/populate_release.sh R1-2024-csp-9 quesnelia
 _Make sure to manually delete any already downloaded JSON files to avoid accidentally including the wrong dependencies for some flower release when executing this script for multiple flower releases._
 
 
+### Populate Node
+
+The **Populate Node** is a supplementary script to the **Populate Release**.
+
+The **Populate Release** script operates based on existing pre-generated install JSON files.
+The **Populate Node** script operates based on generating the install JSON files using the **FOLIO NPM Registry** (or whichever registry is configured via the `~/.yarnrc` file).
+
+The install JSON file by default is named `npm.json` by default to prevent confusing it with the other install JSON files, such as `install.json` and `eureka-platform.json`.
+This `npm.json` file is re-created on every run of this script.
+
+The currently implementation of this script limits the packages being operated on to those prefixed with `@folio/` in their package name.
+
+This is intended to handle the small number of packages that are known to not be available directly in the **FOLIO Registry**, namely `@folio/authorization-policies` and `@folio/authorization-roles`.
+
+Example usage:
+```shell
+bash script/populate_node.sh
+```
+
+
 #### Populate via Branches and Commit Hashes
 
 The population can be done via a branch name or a commit hash rather than only a tag name.
@@ -123,7 +143,7 @@ These input variables are available both as input variables for event triggers a
 
 |      Input Variable     |   Type    | Description
 | ----------------------- | --------- | -----------
-| `debug_mode`            | string    | Enables debugging when non-empty. Special options (space separated): `curl`, `git`, `json`, `verify`, `curl_only`, `git_only`, `json_only`, and `verify_only`.
+| `debug_mode`            | string    | Enables debugging when non-empty. Special options (space separated): `curl`, `git`, `json`, `verify`, `yarn`, `curl_only`, `git_only`, `json_only`, `verify_only`, and `yarn_only`.
 | `registry_branch`       | string    | The name of the branch containing the registry descriptor files, such as `snapshot`.
 | `script_branch`         | string    | The name of the branch containing the scripts, such as `master`.
 

--- a/script/build_latest.sh
+++ b/script/build_latest.sh
@@ -21,7 +21,6 @@
 #
 # The BUILD_LATEST_DEBUG may be specifically set to "json" to include printing the JSON files.
 # The BUILD_LATEST_DEBUG may be specifically set to "json_only" to only print the JSON files, disabling all other debugging (does not pass -v).
-# Otherwise, any non-empty value will result in debug printing without the git command.
 #
 # If neither the BUILD_LATEST_FILES nor the command line parameter files are passed then the default file is used.
 #
@@ -29,7 +28,7 @@
 main() {
   local debug=
   local debug_json=
-  local files="install.json eureka-platform.json"
+  local files="install.json eureka-platform.json npm.json"
   local ignore=
   local path="release/snapshot/"
 
@@ -49,6 +48,15 @@ main() {
   return ${result}
 }
 
+build_latest_handle_result() {
+  let result=${?}
+
+  if [[ ${result} -ne 0 ]] ; then
+    echo "${1}"
+    echo
+  fi
+}
+
 build_latest_load_environment() {
   local i=
   local file=
@@ -56,9 +64,9 @@ build_latest_load_environment() {
   if [[ ${BUILD_LATEST_DEBUG} != "" ]] ; then
     debug="-v"
 
-    if [[ ${BUILD_LATEST_DEBUG} == "json" ]] ; then
+    if [[ $(echo ${BUILD_LATEST_DEBUG} | grep -sho "^\s*json\s*$") != "" ]] ; then
       debug_json="y"
-    elif [[ ${BUILD_LATEST_DEBUG} == "json_only" ]] ; then
+    elif [[ $(echo ${BUILD_LATEST_DEBUG} | grep -sho "^\s*json_only\s*$") != "" ]] ; then
       debug=
       debug_json="y"
     elif [[ $(echo ${BUILD_LATEST_DEBUG} | grep -sho "_only") != "" ]] ; then
@@ -145,15 +153,6 @@ build_latest_load_environment() {
         build_latest_handle_result "${p_e}The following path is could not be created: ${path} ."
       fi
     fi
-  fi
-}
-
-build_latest_handle_result() {
-  let result=${?}
-
-  if [[ ${result} -ne 0 ]] ; then
-    echo "${1}"
-    echo
   fi
 }
 

--- a/script/build_pages.sh
+++ b/script/build_pages.sh
@@ -29,10 +29,8 @@
 #
 # The BUILD_PAGES_DEBUG may be specifically set to "json" to include printing the JSON files.
 # The BUILD_PAGES_DEBUG may be specifically set to "json_only" to only print the JSON files, disabling all other debugging (does not pass -v).
-# Otherwise, any non-empty value will result in debug printing without the git command.
 # The BUILD_PAGES_DEBUG may be specifically set to "verify" to include printing the individual verify/process file messages.
 # The BUILD_PAGES_DEBUG may be specifically set to "verify_only" to only print the the individual verify/process file messages, disabling all other debugging (does not pass -v).
-# Otherwise, any non-empty value will result in debug printing without the git command.
 #
 # If any of BUILD_PAGES_TEMPLATE_BASE, BUILD_PAGES_TEMPLATE_ITEM, or BUILD_PAGES_TEMPLATE_PATH are not specified, then the default is loaded for each unspecified variable.
 #
@@ -68,6 +66,14 @@ main() {
   return ${result}
 }
 
+build_page_handle_result() {
+  let result=${?}
+
+  if [[ ${result} -ne 0 ]] ; then
+    echo "${1}"
+  fi
+}
+
 build_page_load_environment() {
   local file=
   local parameter=
@@ -76,11 +82,11 @@ build_page_load_environment() {
   if [[ ${BUILD_PAGES_DEBUG} != "" ]] ; then
     debug="-v"
 
-    if [[ ${BUILD_PAGES_DEBUG} == "json" ]] ; then
+    if [[ $(echo ${BUILD_PAGES_DEBUG} | grep -sho "^\s*json\s*$") != "" ]] ; then
       debug_json="y"
-    elif [[ ${BUILD_PAGES_DEBUG} == "verify" ]] ; then
+    elif [[ $(echo ${BUILD_PAGES_DEBUG} | grep -sho "^\s*verify\s*$") != "" ]] ; then
       debug_verify="y"
-    elif [[ ${BUILD_PAGES_DEBUG} == "json_only" ]] ; then
+    elif [[ $(echo ${BUILD_PAGES_DEBUG} | grep -sho "^\s*json_only\s*$") != "" ]] ; then
       debug=
       debug_json="y"
     elif [[ $(echo ${BUILD_PAGES_DEBUG} | grep -sho "_only") != "" ]] ; then
@@ -189,14 +195,6 @@ build_page_load_environment() {
 
       sources="${sources}${file} "
     done
-  fi
-}
-
-build_page_handle_result() {
-  let result=${?}
-
-  if [[ ${result} -ne 0 ]] ; then
-    echo "${1}"
   fi
 }
 

--- a/script/populate_node.sh
+++ b/script/populate_node.sh
@@ -1,0 +1,414 @@
+#!/bin/bash
+#
+# Populate part of a release based on a Node package.
+#
+# This is intended to act as a supplement to the populate_release.sh script for packages that are in the Node package system and are not defined in an install.json file or similar.
+# This should only be used for packages not in an existing install.json file or similar.
+#
+# The Node/NPM/Yarn registry provides a way to fetch projects as dependencies but does not provide a way to fetch as a project.
+# This, therefore, fetches as dependencies, then changes into the dependency directories and builds the module descriptor using stripes-cli.
+# Using GitHub to clone the repository does not work as intended because GitHub does not provide the custom detailed build version, such as 2.0.10990000000060.
+# Simply downloading the GitHub repository and changing the version number may result in discrepancies as well.
+#
+# Note that the version of any package can be determined using: `yarn info @folio/authorization-roles version --json`.
+#
+# This script currently only understands packages prefixed with `@folio/` in the package.json.
+#
+# This requires the following user-space programs:
+#   - bash
+#   - grep
+#   - jq
+#   - sed
+#   - stripes-cli
+#   - yarn
+#
+#  Parameters:
+#    None.
+#
+#  Environment Variables:
+#    POPULATE_NODE_DEBUG:       Enable debug verbosity, any non-empty string enables this.
+#    POPULATE_NODE_DESTINATION: Destination directory the release files are stored in (this defaults to `${PWD}/release/snapshot`).
+#    POPULATE_NODE_NPM_DIR:     Designate a directory where the NPM JSON file is located (this defaults to `${PWD}`).
+#    POPULATE_NODE_NPM_FILE:    The name of the NPM JSON file used to hold the generated projects and versions.
+#    POPULATE_NODE_PROJECTS:    Designate the (space-separated) projects to operate on (specifying this overrides the default).
+#    POPULATE_NODE_SKIP_BAD:    Skip projects that fail to fetch and build instead of aborting the script, any non-empty string enables this.
+#    POPULATE_NODE_WORKSPACE:   Designate a workspace directory to use (This directory must already have a `package.json` workspace file).
+#
+# The POPULATE_NODE_DEBUG may be specifically set to "json" to include printing the JSON files.
+# The POPULATE_NODE_DEBUG may be specifically set to "json_only" to only print the JSON files, disabling all other debugging (does not pass -v).
+# The POPULATE_NODE_DEBUG may be specifically set to "yarn" to include running yarn in verbose mode.
+# The POPULATE_NODE_DEBUG may be specifically set to "yarn_only" to only include running yarn in verbose mode, disabling all other debugging (does not pass -v).
+#
+# A workspace `package.json` file looks like:
+#   ```json
+#     {
+#       "name": "workspace",
+#       "private": true,
+#       "version": "1.0.0",
+#       "workspaces": [ "*" ],
+#       "dependencies": { }
+#     }
+#   ```
+#
+
+main() {
+  local debug=
+  local debug_json=
+  local debug_yarn="-s"
+  local destination=
+  local npm_dir=$(echo ${PWD} | sed -e 's|/*$|/|')
+  local npm_file="npm.json"
+  local projects="@folio/authorization-policies @folio/authorization-roles"
+  local workspace="${PWD}/workspace/"
+
+  # Custom prefixes for debug and error.
+  local p_d="DEBUG: "
+  local p_e="ERROR: "
+
+  local -i result=0
+  local -i skip_bad=0
+
+  destination=${npm_dir}release/snapshot/
+
+  pop_node_load_environment
+
+  pop_node_verify_files
+
+  pop_node_process_projects
+
+  return ${result}
+}
+
+pop_node_handle_result() {
+  let result=${?}
+
+  if [[ ${result} -ne 0 ]] ; then
+    echo "${1}"
+    echo
+  fi
+}
+
+pop_node_load_environment() {
+  local project=
+
+  if [[ ${POPULATE_NODE_DEBUG} != "" ]] ; then
+    debug="-v"
+    debug_json=
+    debug_yarn="-s"
+
+    if [[ $(echo ${POPULATE_NODE_DEBUG} | grep -sho "^\s*json\s*$") != "" ]] ; then
+      debug_json="y"
+    elif [[ $(echo ${POPULATE_NODE_DEBUG} | grep -sho "^\s*yarn\s*$") != "" ]] ; then
+      debug_yarn="--verbose"
+    elif [[ $(echo ${POPULATE_NODE_DEBUG} | grep -sho "^\s*json_only\s*$") != "" ]] ; then
+      debug=
+      debug_json="y"
+    elif [[ $(echo ${POPULATE_NODE_DEBUG} | grep -sho "^\s*yarn_only\s*$") != "" ]] ; then
+      debug=
+      debug_yarn="--verbose"
+    elif [[ $(echo ${POPULATE_NODE_DEBUG} | grep -sho "_only") != "" ]] ; then
+      debug=
+    else
+      if [[ $(echo ${POPULATE_NODE_DEBUG} | grep -sho "\<json\>") != "" ]] ; then
+        debug_json="y"
+      fi
+
+      if [[ $(echo ${POPULATE_NODE_DEBUG} | grep -sho "\<yarn\>") != "" ]] ; then
+        debug_yarn="--verbose"
+      fi
+    fi
+  fi
+
+  if [[ $(echo -n ${POPULATE_NODE_DESTINATION} | sed -e 's|\s||g') != "" ]] ; then
+    destination=$(echo -n ${POPULATE_NODE_DESTINATION} | sed -e 's|//*|/|g' -e 's|/*$|/|g')
+  fi
+
+  if [[ $(echo -n ${POPULATE_NODE_NPM_DIR} | sed -e 's|\s||g') != "" ]] ; then
+    npm_dir=$(echo -n ${POPULATE_NODE_NPM_DIR} | sed -e 's|//*|/|g' -e 's|/*$|/|g')
+  fi
+
+  if [[ ${POPULATE_NODE_NPM_FILE} != "" ]] ; then
+    npm_file=$(echo -n ${POPULATE_NODE_NPM_FILE} | sed -e 's|//*|/|g' -e 's|/*$||g')
+  fi
+
+  if [[ $(echo -n ${POPULATE_NODE_PROJECTS} | sed -e 's|\s||g') != "" ]] ; then
+    projects=
+
+    for project in ${POPULATE_NODE_PROJECTS} ; do
+      projects="${projects}${project} "
+    done
+  fi
+
+  if [[ $(echo -n ${POPULATE_NODE_SKIP_BAD} | sed -e 's|\s||g') != "" ]] ; then
+    let skip_bad=1
+  fi
+
+  if [[ ${POPULATE_NODE_WORKSPACE} != "" ]] ; then
+    workspace=$(echo -n ${POPULATE_NODE_WORKSPACE} | sed -e 's|//*|/|g' -e 's|/*$|/|g')
+
+    # If the workspace path is relative, make it absolute.
+    if [[ $(echo ${workspace} | grep -sho '^/') == "" ]] ; then
+      workspace="${PWD}/${workspace}"
+    elif [[ $(echo ${workspace} | grep -sho '^\./') != "" ]] ; then
+      workspace=$(echo -n ${workspace} | sed -e "s|^\./|${PWD}/|")
+    fi
+  fi
+}
+
+pop_node_print_debug() {
+
+  if [[ ${debug} == "" ]] ; then return ; fi
+
+  echo "${p_d}${1} ."
+  echo
+}
+
+pop_node_process_projects() {
+  local project=
+  local project_simple=
+  local version=
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  # Use pushd/popd from bash to better control directory transitioning and restoration on error.
+  pushd ${workspace}
+
+  pop_node_handle_result "Failed to change into workspace directory: ${workspace}"
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  for project in ${projects} ; do
+
+    project_simple=$(echo -n ${project} | sed -e 's|^.*/||')
+    version=
+
+    echo
+    echo "Operating on ${project} (simple: ${project_simple})."
+
+    pop_node_process_projects_fetch
+
+    pop_node_process_projects_into_project
+
+    pop_node_process_projects_build_descriptor
+
+    pop_node_process_projects_extract_version
+
+    pop_node_process_projects_copy_descriptor
+
+    pop_node_process_projects_update_npm_json
+
+    pop_node_process_projects_into_workspace
+
+    if [[ ${result} -ne 0 ]] ; then
+      if [[ ${skip_bad} -ne 0 ]] ; then continue ; fi
+
+      break
+    fi
+  done
+
+  # Always pop the directory stack to return to the starting directory.
+  popd
+}
+
+pop_node_process_projects_build_descriptor() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  yarn ${debug_yarn} run --non-interactive build-mod-descriptor
+
+  pop_node_handle_result "Failed to build module descriptor for the project: ${project} (simple: ${project_simple})"
+}
+
+pop_node_process_projects_copy_descriptor() {
+  local name=folio_${project}
+  local release="${destination}folio_${project_simple}-${version}"
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  cp ${debug} module-descriptor.json ${release}
+
+  pop_node_handle_result "Failed to copy the module descriptor for the ${project} (simple: ${project_simple}) to: ${release}"
+}
+
+pop_node_process_projects_extract_version() {
+  local file="package.json"
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  if [[ ! -f ${file} ]] ; then
+    echo "${p_e}The ${file} file is either missing or not a valid regular file for: ${project} (simple: ${project_simple})."
+
+    let result=1
+
+    return;
+  fi
+
+  version=$(jq -M '.version' ${file} | sed -e 's|"||g' -e 's|\s||g')
+
+  if [[ ${version} == "" ]] ; then
+    echo "${p_e}The ${file} file has no valid version ('${version}') for: ${project} (simple: ${project_simple})."
+
+    let result=1
+  fi
+}
+
+pop_node_process_projects_fetch() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  yarn ${debug_yarn} add -W --non-interactive ${project}
+
+  pop_node_handle_result "Failed to fetch the project: ${project} (simple: ${project_simple})"
+}
+
+pop_node_process_projects_into_project() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  pop_node_print_debug "cd \"node_modules/${project}/\""
+
+  cd "node_modules/${project}/"
+
+  pop_node_handle_result "Failed to change into project directory: node_modules/${project}/"
+}
+
+pop_node_process_projects_into_workspace() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  pop_node_print_debug "cd ${workspace}"
+
+  cd ${workspace}
+
+  pop_node_handle_result "Failed to change into workspace directory: ${workspace}"
+}
+
+pop_node_process_projects_update_npm_json() {
+  local json=
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  # Work around JQ's problems with empty arrays when appending files.
+  if [[ ! -f ${npm_dir}${npm_file} ]] ; then
+    pop_node_print_debug "echo \"[{ \\\"id\\\": \\\"folio_${project_simple}-${version}\\\", \\\"action\\\": \\\"enable\\\" }]\" > ${npm_dir}${npm_file}"
+
+    echo "[{ \"id\": \"folio_${project_simple}-${version}\", \"action\": \"enable\" }]" > ${npm_dir}${npm_file}
+  else
+    # Work around JQ's problems with using the input as the output.
+    json=$(cat ${npm_dir}${npm_file})
+
+    pop_node_print_debug "echo ${json} | jq \". |= . + [{ \\\"id\\\": \\\"folio_${project_simple}-${version}\\\", \\\"action\\\": \\\"enable\\\" }]\" > ${npm_dir}${npm_file}"
+
+    echo ${json} | jq ". |= . + [{ \"id\": \"folio_${project_simple}-${version}\", \"action\": \"enable\" }]" > ${npm_dir}${npm_file}
+  fi
+
+  pop_node_handle_result "Failed to add the version (${version}) for the project ${project} (simple: ${project_simple}) to: ${npm_dir}${npm_file}"
+}
+
+pop_node_verify_files() {
+  local workspace_file=${workspace}package.json
+  local workspace_json="{ \"name\": \"workspace\", \"private\": true, \"version\": \"1.0.0\", \"workspaces\": [ \"*\" ], \"dependencies\": { } }"
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  pop_node_verify_files_workspace
+
+  pop_node_verify_files_workspace_file
+
+  pop_node_verify_files_workspace_file_json
+
+  pop_node_verify_files_npm_file
+
+  pop_node_verify_files_destination
+}
+
+pop_node_verify_files_destination() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  if [[ -e ${destination} ]] ; then
+    if [[ ! -d ${destination} ]] ; then
+      echo "${p_e}The NPM JSON file is not and must be a directory file: ${destination} ."
+
+      let result=1
+    fi
+
+    return
+  fi
+
+  mkdir ${debug} -p ${destination}
+
+  pop_node_handle_result "Failed to create destination directory: ${destination}"
+}
+
+pop_node_verify_files_npm_file() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  if [[ -e ${npm_dir}${npm_file} ]] ; then
+    if [[ ! -f ${npm_dir}${npm_file} ]] ; then
+      echo "${p_e}The NPM JSON file is not and must be a regular file: ${npm_dir}${npm_file} ."
+
+      let result=1
+
+      return
+    fi
+  fi
+
+  # Re-create the NPM file on each run of this script.
+  rm ${debug} -f ${npm_dir}${npm_file}
+
+  pop_node_handle_result "Failed to create NPM JSON file: ${npm_dir}${npm_file}"
+}
+
+pop_node_verify_files_workspace() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  pop_node_print_debug "Verifying workspace directory: ${workspace}"
+
+  if [[ -e ${workspace} ]] ; then
+    if [[ ! -d ${workspace} ]] ; then
+      echo "${p_e}The workspace is not and must be a directory: ${workspace} ."
+
+      let result=1
+    fi
+  elif [[ ! -d ${workspace} ]] ; then
+    mkdir ${debug} -p ${workspace}
+
+    pop_node_handle_result "Failed to create workspace directory: ${workspace}"
+  fi
+}
+
+pop_node_verify_files_workspace_file() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  if [[ -e ${workspace_file} ]] ; then
+    if [[ ! -f ${workspace_file} ]] ; then
+      echo "${p_e}The workspace JSON file is not and must be a regular file: ${workspace_file} ."
+
+      let result=1
+    fi
+  else
+    echo ${workspace_json} > ${workspace_file}
+
+    pop_node_handle_result "Failed to create workspace file: ${workspace_file}"
+  fi
+}
+
+pop_node_verify_files_workspace_file_json() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  # Prevent jq from printing JSON if /dev/null exists when not debugging.
+  if [[ ${debug_json} != "" || ! -e /dev/null ]] ; then
+    cat ${workspace_file} | jq
+  else
+    cat ${workspace_file} | jq >> /dev/null
+  fi
+
+  pop_node_handle_result "Invalid workspace JSON file: ${workspace_file}"
+}
+
+main $*

--- a/script/populate_release.sh
+++ b/script/populate_release.sh
@@ -32,7 +32,6 @@
 #
 # The POPULATE_RELEASE_DEBUG may be specifically set to "curl" to include printing the curl commands.
 # The POPULATE_RELEASE_DEBUG may be specifically set to "curl_only" to only print the curl commands, disabling all other debugging (does not pass -v to curl).
-# Otherwise, any non-empty value will result in debug printing without the curl command.
 #
 # The POPULATE_RELEASE_CURL_FAIL designate the fail mode of either "fail" or "continue".
 #
@@ -83,6 +82,15 @@ main() {
   return ${result}
 }
 
+pop_rel_handle_result() {
+  let result=${?}
+
+  if [[ ${result} -ne 0 ]] ; then
+    echo "${1}"
+    echo
+  fi
+}
+
 pop_rel_load_environment() {
   local i=
   local file=
@@ -99,9 +107,9 @@ pop_rel_load_environment() {
     debug="-v"
     debug_curl=
 
-    if [[ ${POPULATE_RELEASE_DEBUG} == "curl" ]] ; then
+    if [[ $(echo ${POPULATE_RELEASE_DEBUG} | grep -sho "^\s*curl\s*$") != "" ]] ; then
       debug_curl="y"
-    elif [[ ${POPULATE_RELEASE_DEBUG} == "curl_only" ]] ; then
+    elif [[ $(echo ${POPULATE_RELEASE_DEBUG} | grep -sho "^\s*curl_only\s*$") != "" ]] ; then
       debug=
       debug_curl="y"
     elif [[ $(echo ${POPULATE_RELEASE_DEBUG} | grep -sho "_only") != "" ]] ; then
@@ -335,15 +343,6 @@ pop_rel_process_sources_curl() {
   curl -w '\n' ${curl_fail} ${debug} ${source} -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'cache-control: no-cache' -o ${file}
 
   pop_rel_handle_result "${p_e}Curl request failed (with system code ${?}) for: ${source} ."
-}
-
-pop_rel_handle_result() {
-  let result=${?}
-
-  if [[ ${result} -ne 0 ]] ; then
-    echo "${1}"
-    echo
-  fi
 }
 
 main $*

--- a/script/sync_snapshot.sh
+++ b/script/sync_snapshot.sh
@@ -19,7 +19,6 @@
 #
 # The SYNC_SNAPSHOT_DEBUG may be specifically set to "git" to include printing the git commands.
 # The SYNC_SNAPSHOT_DEBUG may be specifically set to "git_only" to only print the git commands, disabling all other debugging (does not pass -v to git).
-# Otherwise, any non-empty value will result in debug printing without the git command.
 #
 # If SYNC_SNAPSHOT_RESULT is a non-empty string, then on handled exit the contents of the specified file name will be "none" for no updates, "updated" for updates", and "failure" on error.
 #
@@ -96,17 +95,6 @@ sync_snap_determine() {
   fi
 }
 
-sync_snap_push() {
-
-  if [[ ${result} -ne 0 ]] ; then return ; fi
-
-  sync_snap_print_git_debug "Pushing" "git push ${debug}"
-
-  git push ${debug}
-
-  sync_snap_handle_result_git "pushing"
-}
-
 sync_snap_handle_result() {
   let result=${?}
 
@@ -133,9 +121,9 @@ sync_snap_load_environment() {
   if [[ ${SYNC_SNAPSHOT_DEBUG} != "" ]] ; then
     debug="-v"
 
-    if [[ ${SYNC_SNAPSHOT_DEBUG} == "git" ]] ; then
+    if [[ $(echo ${SYNC_SNAPSHOT_DEBUG} | grep -sho "^\s*git\s*$") != "" ]] ; then
       debug_git="y"
-    elif [[ ${SYNC_SNAPSHOT_DEBUG} == "git_only" ]] ; then
+    elif [[ $(echo ${SYNC_SNAPSHOT_DEBUG} | grep -sho "^\s*git_only\s*$") != "" ]] ; then
       debug=
       debug_git="y"
     elif [[ $(echo ${SYNC_SNAPSHOT_DEBUG} | grep -sho "_only") != "" ]] ; then
@@ -172,6 +160,17 @@ sync_snap_print_git_debug() {
 
   echo "${p_d}${1} Git Changes: ${2} ."
   echo
+}
+
+sync_snap_push() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  sync_snap_print_git_debug "Pushing" "git push ${debug}"
+
+  git push ${debug}
+
+  sync_snap_handle_result_git "pushing"
 }
 
 main $*

--- a/workspace/package.json
+++ b/workspace/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "workspace",
+  "private": true,
+  "version": "1.0.0",
+  "workspaces": [ "*" ],
+  "dependencies": { }
+}


### PR DESCRIPTION
Place the environment variables on their own lines when running scripts to make them easier to read.

Add the `populate_node.sh` script and the `workspace` directory.
- This now requires `stripes-cli` to be installed in the runner.
- This generates an `npm.json` file that is intended to be structured the same as the `install.json` file.
- This avoids appending to the `install.json` file to maintain separation of concerns and to avoid `jq` bugs (The `jq` does not handle common command line behaviors and designs very well and requires work-arounds).
- This `npm.json` file gets re-created on every script run (which also helps avoid `jq` problems).
- Try to suppress `yarn` messages when not in debug mode (the warnings aren't easily suppressed unfortunately).
- The module descriptor is generated using the `stripes-cli` which is then copied into the release directory.
- The generated module descriptor is then used to populate the `npm.json` file using the specific version from the `package.json` file.

The `workspace` directory is used to help facilitate downloading the needed packages. I have been unable to find a way to use the registry to download the package from the NPM registry as the package itself (similar to a git clone). Instead, the script is forced to add the packages as a dependency to the workspace. The script then must change into the appropriate `node_modules` sub-directory to process and build the module descriptor. Using GitHub is out of the question because it fails to store the very specific NPM version number that is needed (such as `folio_authorization-roles-2.0.109900000000137`).

Rename `populate_snapshot` to `populate_release` to be more accurate and consistent with the name.

Make the `DEBUG` parameters be more tolerant of leading and trailing spaces in the debug values for all scripts. Fix alphabetical ordering issue of some of the `_handle_result()` Bash functions.

Remove the `# Otherwise, any non-empty...` comment to simplify the script documentation.

Add single quotes around inputs in `run-name` to help make debugging easier (the cron runs appear to have a default parameter problem).

Assure that `stripes-cli` is installed when running the workflow.