### PR TITLE
Work-around GitHub insufficiency regarding defaults during scheduler run.

### DIFF
--- a/.github/workflows/sync_snapshot.yml
+++ b/.github/workflows/sync_snapshot.yml
@@ -2,6 +2,8 @@ name: Synchronize Snapshot
 run-name: Synchronize Snapshot using script branch '${{ inputs.script_branch }}' and registry branch '${{ inputs.registry_branch }}' by @${{ github.actor }}
 
 on:
+
+  # Note: GitHub Actions fail to recognize default values for inputs on schedule run, so the defaults must be re-applied on each use via something like ` || 'snapshot'`.
   schedule:
     - cron: '0 0 */1 * *'
 
@@ -79,14 +81,14 @@ jobs:
         name: Checkout Registry
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.registry_branch }}
+          ref: ${{ inputs.registry_branch || 'snapshot' }}
           path: ${{steps.initialize_instance.outputs.instance}}/populate
 
       - id: checkout_scripts
         name: Checkout Scripts
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.script_branch }}
+          ref: ${{ inputs.script_branch || 'master' }}
           path: ${{steps.initialize_instance.outputs.instance}}/scripts
           sparse-checkout: |
             script/populate_node.sh
@@ -147,5 +149,5 @@ jobs:
     uses: ./.github/workflows/gh_pages.yml
     with:
       debug_mode: ${{ inputs.debug_mode }}
-      registry_branch: ${{ inputs.registry_branch }}
-      script_branch: ${{ inputs.script_branch }}
+      registry_branch: ${{ inputs.registry_branch || 'snapshot' }}
+      script_branch: ${{ inputs.script_branch || 'master' }}


### PR DESCRIPTION
GitHub fails to honor the input defaults (or fails to provide input defaults support) for scheduler runs. This insufficiency can either be worked around by mapping the inputs to the outputs and applying a default or by just appending ` || 'some_string'` to every variable usage.

Applying the ` || 'some_string'` logic currently makes more sense because there are a small number of use cases of the input variables.

I would delete the `default` entirely, but this `default` is used in the form input on the GUI side.

This can only be truly tested on a cron run and therefore must be merged before behavior works as intended.

According to the GitHub documentation equality comparisons on an empty string returns `0`. The use of the `||` (or) operator should work here.

see: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#operators
see: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#functions