### PR TITLE
Documentation improvements and fix some inconsistencies in the scripts.

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -80,7 +80,6 @@ jobs:
           path: ${{steps.initialize_instance.outputs.instance}}/scripts
           sparse-checkout: |
             script/build_pages.sh
-            setting
             template
 
       - name: Generate Directory Listings

--- a/.github/workflows/sync_snapshot.yml
+++ b/.github/workflows/sync_snapshot.yml
@@ -92,7 +92,6 @@ jobs:
             script/populate_node.sh
             script/populate_release.sh
             script/sync_snapshot.sh
-            setting
             workspace
 
       - id: populate_release

--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ This script takes a simple approach of creating a symbolic link to the version s
 The order in which the files are passed determines the order (left to right) in which overwrites of existing symbolic links are performed.
 The default behavior is to use the `-latest` in place of the version suffix.
 
-| Environment Variable Name        | Description (see script for further details)
-| -------------------------------- | --------------------------------
-| BUILD_LATEST_DEBUG               | Enable debug verbosity, any non-empty string enables this.
-| BUILD_LATEST_FILES               | A list of files to build.
-| BUILD_LATEST_PATH                | The destination path to write to.
-| BUILD_LATEST_SKIP_NOT_FOUND      | Skip version files that are not found, any non-empty string enables this.
+| Environment Variable               | Description (see script for further details)
+| ---------------------------------- | --------------------------------
+| `BUILD_LATEST_DEBUG`               | Enable debug verbosity, any non-empty string enables this.
+| `BUILD_LATEST_FILES`               | A list of files to build.
+| `BUILD_LATEST_PATH`                | The destination path to write to.
+| `BUILD_LATEST_SKIP_NOT_FOUND`      | Skip version files that are not found, any non-empty string enables this.
 
 View the documentation within the `build_latest.sh` script for further details on how to operate this script.
 
@@ -85,16 +85,16 @@ The `sed` statements in the script will need to be edited to enhance the templat
 | `_REPLACE_SECTION_TITLE_`   | A title to be displayed in HTML.
 | `_REPLACE_SECTION_SNIPPET_` | Used by the script to apply the `item.html` template (explicitly intended to have HTML).
 
-| Environment Variable Name        | Description (see script for further details)
-| -------------------------------- | --------------------------------
-| BUILD_PAGES_BASE                 | The base URL where the generated pages are stored.
-| BUILD_PAGES_DEBUG                | Enable debug verbosity, any non-empty string enables this.
-| BUILD_PAGES_IGNORE_INVALID       | Ignore non-JSON files rather than fail, any non-empty string enables this.
-| BUILD_PAGES_TEMPLATE_BACK        | The name of the back HTML template within the `BUILD_PAGES_TEMPLATE_PATH` directory.
-| BUILD_PAGES_TEMPLATE_BASE        | The name of the base HTML template within the `BUILD_PAGES_TEMPLATE_PATH` directory.
-| BUILD_PAGES_TEMPLATE_ITEM        | The name of the item HTML template within the `BUILD_PAGES_TEMPLATE_PATH` directory.
-| BUILD_PAGES_TEMPLATE_PATH        | The path to the template directory containing the HTML template files.
-| BUILD_PAGES_WORK                 | A working directory used to create the GitHub Pages structure (all templates and files are added here).
+| Environment Variable               | Description (see script for further details)
+| ---------------------------------- | --------------------------------
+| `BUILD_PAGES_BASE`                 | The base URL where the generated pages are stored.
+| `BUILD_PAGES_DEBUG`                | Enable debug verbosity, any non-empty string enables this.
+| `BUILD_PAGES_IGNORE_INVALID`       | Ignore non-JSON files rather than fail, any non-empty string enables this.
+| `BUILD_PAGES_TEMPLATE_BACK`        | The name of the back HTML template within the `BUILD_PAGES_TEMPLATE_PATH` directory.
+| `BUILD_PAGES_TEMPLATE_BASE`        | The name of the base HTML template within the `BUILD_PAGES_TEMPLATE_PATH` directory.
+| `BUILD_PAGES_TEMPLATE_ITEM`        | The name of the item HTML template within the `BUILD_PAGES_TEMPLATE_PATH` directory.
+| `BUILD_PAGES_TEMPLATE_PATH`        | The path to the template directory containing the HTML template files.
+| `BUILD_PAGES_WORK`                 | A working directory used to create the GitHub Pages structure (all templates and files are added here).
 
 View the documentation within the `build_pages.sh` script for further details on how to operate this script.
 
@@ -111,18 +111,18 @@ This release is then used to fetch all of the available module descriptors from 
 
 The flower release name in relation to its release date designation (which maps to the tag name) can be found on the **FOLIO Project** wiki in the [Flower Release Names](https://folio-org.atlassian.net/wiki/spaces/REL/pages/5210505/Flower+Release+Names) page.
 
-| Environment Variable Name        | Description (see script for further details)
-| -------------------------------- | --------------------------------
-| POPULATE_RELEASE_CURL_FAIL       | Designate how to handle curl failures. This can be one of `fail`, `none`, and `report` (default).
-| POPULATE_RELEASE_DEBUG           | Enable debug verbosity, any non-empty string enables this.
-| POPULATE_RELEASE_DESTINATION     | Destination parent directory.
-| POPULATE_RELEASE_FILE_REUSE      | Enable re-using existing JSON files without GET fetching, any non-empty string enables this.
-| POPULATE_RELEASE_FILES           | The name of space separated JSON files, such as `install.json` and `eureka-platform.json` to GET fetch and store locally for processing.
-| POPULATE_RELEASE_FLOWER          | The Flower release name, such as `quesnelia` or `snapshot`.
-| POPULATE_RELEASE_REGISTRY        | The URL to GET the module descriptor from for some specific module version.
-| POPULATE_RELEASE_REPOSITORY      | The raw GitHub repository URL to fetch from (but without the URL parts after the repository name).
-| POPULATE_RELEASE_REPOSITORY_PART | The part of the GitHub repository URL specifying the tag, branch, or hash (but without either the specific tag/branch name or the file path).
-| POPULATE_RELEASE_TAG             | The GitHub release tag, such as `R1-2024-csp-9`.
+| Environment Variable               | Description (see script for further details)
+| ---------------------------------- | --------------------------------
+| `POPULATE_RELEASE_CURL_FAIL`       | Designate how to handle curl failures. This can be one of `fail`, `none`, and `report` (default).
+| `POPULATE_RELEASE_DEBUG`           | Enable debug verbosity, any non-empty string enables this.
+| `POPULATE_RELEASE_DESTINATION`     | Destination parent directory.
+| `POPULATE_RELEASE_FILE_REUSE`      | Enable re-using existing JSON files without GET fetching, any non-empty string enables this.
+| `POPULATE_RELEASE_FILES`           | The name of space separated JSON files, such as `install.json` and `eureka-platform.json` to GET fetch and store locally for processing.
+| `POPULATE_RELEASE_FLOWER`          | The Flower release name, such as `quesnelia` or `snapshot`.
+| `POPULATE_RELEASE_REGISTRY`        | The URL to GET the module descriptor from for some specific module version.
+| `POPULATE_RELEASE_REPOSITORY`      | The raw GitHub repository URL to fetch from (but without the URL parts after the repository name).
+| `POPULATE_RELEASE_REPOSITORY_PART` | The part of the GitHub repository URL specifying the tag, branch, or hash (but without either the specific tag/branch name or the file path).
+| `POPULATE_RELEASE_TAG`             | The GitHub release tag, such as `R1-2024-csp-9`.
 
 View the documentation within the `populate_release.sh` script for further details on how to operate this script.
 
@@ -167,15 +167,15 @@ The current implementation of this script limits the packages being operated on 
 
 This is intended to handle the small number of packages that are known to not be available directly in the **FOLIO Registry**, namely `@folio/authorization-policies` and `@folio/authorization-roles`.
 
-| Environment Variable Name        | Description (see script for further details)
-| -------------------------------- | --------------------------------
-| POPULATE_NODE_DEBUG              | Enable debug verbosity, any non-empty string enables this.
-| POPULATE_NODE_DESTINATION        | Destination directory the release files are stored in (this defaults to `${PWD}/release/snapshot`).
-| POPULATE_NODE_NPM_DIR            | Designate a directory where the NPM JSON file is located (this defaults to `${PWD}`).
-| POPULATE_NODE_NPM_FILE           | The name of the NPM JSON file used to hold the generated projects and versions.
-| POPULATE_NODE_PROJECTS           | Designate the (space-separated) projects to operate on (specifying this overrides the default).
-| POPULATE_NODE_SKIP_BAD           | Skip projects that fail to fetch and build instead of aborting the script, any non-empty string enables this.
-| POPULATE_NODE_WORKSPACE          | Designate a workspace directory to use (This directory must already have a `package.json` workspace file).
+| Environment Variable               | Description (see script for further details)
+| ---------------------------------- | --------------------------------
+| `POPULATE_NODE_DEBUG`              | Enable debug verbosity, any non-empty string enables this.
+| `POPULATE_NODE_DESTINATION`        | Destination directory the release files are stored in (this defaults to `${PWD}/release/snapshot`).
+| `POPULATE_NODE_NPM_DIR`            | Designate a directory where the NPM JSON file is located (this defaults to `${PWD}`).
+| `POPULATE_NODE_NPM_FILE`           | The name of the NPM JSON file used to hold the generated projects and versions.
+| `POPULATE_NODE_PROJECTS`           | Designate the (space-separated) projects to operate on (specifying this overrides the default).
+| `POPULATE_NODE_SKIP_BAD`           | Skip projects that fail to fetch and build instead of aborting the script, any non-empty string enables this.
+| `POPULATE_NODE_WORKSPACE`          | Designate a workspace directory to use (This directory must already have a `package.json` workspace file).
 
 View the documentation within the `populate_node.sh` script for further details on how to operate this script.
 
@@ -189,13 +189,13 @@ POPULATE_NODE_WORKSPACE="/path/to/workspace" bash script/populate_node.sh
 
 The **Synchronize Snapshot** script identifies whether or no changes are detected and preforms the necessary `git` operations to push those changes to an upstream repository.
 
-| Environment Variable Name        | Description (see script for further details)
-| -------------------------------- | --------------------------------
-| SYNC_SNAPSHOT_DEBUG              | Enable debug verbosity, any non-empty string enables this.
-| SYNC_SNAPSHOT_MESSAGE            | Specify a custom message to use for the commit.
-| SYNC_SNAPSHOT_PATH               | Designate a path in which to analyze (default is an empty string, which means current directory).
-| SYNC_SNAPSHOT_RESULT             | The file name to write the results of this script to.
-| SYNC_SNAPSHOT_SIGN               | Set to "yes" to explicitly sign, set to "no" to explicitly not sign, and do not set (or set to empty string) to use user-space default.
+| Environment Variable               | Description (see script for further details)
+| ---------------------------------- | --------------------------------
+| `SYNC_SNAPSHOT_DEBUG`              | Enable debug verbosity, any non-empty string enables this.
+| `SYNC_SNAPSHOT_MESSAGE`            | Specify a custom message to use for the commit.
+| `SYNC_SNAPSHOT_PATH`               | Designate a path in which to analyze (default is an empty string, which means current directory).
+| `SYNC_SNAPSHOT_RESULT`             | The file name to write the results of this script to.
+| `SYNC_SNAPSHOT_SIGN`               | Set to "yes" to explicitly sign, set to "no" to explicitly not sign, and do not set (or set to empty string) to use user-space default.
 
 View the documentation within the `synchronize_snapshot.sh` script for further details on how to operate this script.
 

--- a/README.md
+++ b/README.md
@@ -13,12 +13,34 @@ The **MDR** **GitHub Pages** may be found at [https://tamulib.github.io/folio-mo
 
 The Module Descriptors for each release are found within the `release/` sub-directory on a separate branch from the scripts (such as `snapshot`).
 
+The [https://repository.folio.org/repository/npm-folioci/](https://repository.folio.org/repository/npm-folioci/) repository is utilized to fetch any `@folio/` UI modules that require manual module descriptor building.
+
 The [FOLIO Application Generator](folio-org/folio-application-generator) should be able to utilize this repository if and when it supports the `Simple` mode.
+
+
+## Navigation
+  - [Scripts](#scripts)
+    - [Build Latest](#build-latest)
+    - [Build Pages](#build-pages)
+    - [Populate Release](#populate-release)
+      - [Populate via Branches and Commit Hashes](#populate-via-branches-and-commit-hashes)
+    - [Populate Node](#populate-node)
+    - [Synchronize Snapshot](#synchronize-snapshot)
+  - [GitHub Workflows](#github-workflows)
+    - [Build GitHub Pages Workflow](#build-github-pages-workflow)
+    - [Synchronize Snapshot Workflow](#synchronize-snapshot-workflow)
+  - [Design and Methodology](#design-and-methodology)
+    - [Repository Branch Design](#repository-branch-design)
+    - [GitHub Workflows Design](#github-workflows-design)
+    - [Self-Hosted Design](#self-hosted-design)
+    - [Separation of Concern Design](#separation-of-concern-design)
+    - [Fail Forward Design](#fail-forward-design)
+    - [Scripting Design](#scripting-design)
 
 
 ## Scripts
 
-This repository provides additional scripts that may help facilitate the generation of the Module Descriptors.
+This repository provides additional scripts that may help facilitate the generation of the Module Descriptors and related Continuous Integration and Continuous Delivery (CI/CD) operations.
 
 
 ### Build Latest
@@ -29,11 +51,18 @@ This script takes a simple approach of creating a symbolic link to the version s
 The order in which the files are passed determines the order (left to right) in which overwrites of existing symbolic links are performed.
 The default behavior is to use the `-latest` in place of the version suffix.
 
+| Environment Variable Name        | Description (see script for further details)
+| -------------------------------- | --------------------------------
+| BUILD_LATEST_DEBUG               | Enable debug verbosity, any non-empty string enables this.
+| BUILD_LATEST_FILES               | A list of files to build.
+| BUILD_LATEST_PATH                | The destination path to write to.
+| BUILD_LATEST_SKIP_NOT_FOUND      | Skip version files that are not found, any non-empty string enables this.
+
 View the documentation within the `build_latest.sh` script for further details on how to operate this script.
 
 Example usage:
 ```shell
-bash script/build_path.sh release/
+BUILD_LATEST_PATH="release/snapshot" bash script/build_latest.sh
 ```
 
 
@@ -46,8 +75,8 @@ The template functionality is not intended to handle complex cases and only util
 The basic structure allows for this process to be extensible but such logic is not implemented.
 The `sed` statements in the script will need to be edited to enhance the template options available.
 
-|      Template Variable      | Description
-| --------------------------- | -----------
+| Template Variable           | Description
+| --------------------------- | --------------------------------
 | `_REPLACE_LINK_`            | A URI (not intended to have HTML).
 | `_REPLACE_LINK_NAME_`       | A name used for representing a link.
 | `_REPLACE_PAGE_BACK_`       | Used by the script to apply the `back.html` template (explicitly intended to have HTML).
@@ -56,11 +85,22 @@ The `sed` statements in the script will need to be edited to enhance the templat
 | `_REPLACE_SECTION_TITLE_`   | A title to be displayed in HTML.
 | `_REPLACE_SECTION_SNIPPET_` | Used by the script to apply the `item.html` template (explicitly intended to have HTML).
 
+| Environment Variable Name        | Description (see script for further details)
+| -------------------------------- | --------------------------------
+| BUILD_PAGES_BASE                 | The base URL where the generated pages are stored.
+| BUILD_PAGES_DEBUG                | Enable debug verbosity, any non-empty string enables this.
+| BUILD_PAGES_IGNORE_INVALID       | Ignore non-JSON files rather than fail, any non-empty string enables this.
+| BUILD_PAGES_TEMPLATE_BACK        | The name of the back HTML template within the `BUILD_PAGES_TEMPLATE_PATH` directory.
+| BUILD_PAGES_TEMPLATE_BASE        | The name of the base HTML template within the `BUILD_PAGES_TEMPLATE_PATH` directory.
+| BUILD_PAGES_TEMPLATE_ITEM        | The name of the item HTML template within the `BUILD_PAGES_TEMPLATE_PATH` directory.
+| BUILD_PAGES_TEMPLATE_PATH        | The path to the template directory containing the HTML template files.
+| BUILD_PAGES_WORK                 | A working directory used to create the GitHub Pages structure (all templates and files are added here).
+
 View the documentation within the `build_pages.sh` script for further details on how to operate this script.
 
 Example usage:
 ```shell
-BUILD_LATEST_PATH="release/snapshot" bash script/build_latest.sh install.json additional.json
+BUILD_PAGES_WORK="../work" bash script/build_pages.sh
 ```
 
 
@@ -69,41 +109,29 @@ BUILD_LATEST_PATH="release/snapshot" bash script/build_latest.sh install.json ad
 The **Populate Release** script helps automate building a list of module versions based on a specific flower release.
 This release is then used to fetch all of the available module descriptors from an upstream source (an `install.json` file), such as those found on the **FOLIO Registry**.
 
-This script is designed to accept environment variables, thereby allowing for easier integration with automation tools such as Docker.
-
-Direct command line use is also supported to allow for individuals to manually execute.
-Most settings, however, are either done via environment variables or by manually toggling the variables within the script.
-
 The flower release name in relation to its release date designation (which maps to the tag name) can be found on the **FOLIO Project** wiki in the [Flower Release Names](https://folio-org.atlassian.net/wiki/spaces/REL/pages/5210505/Flower+Release+Names) page.
+
+| Environment Variable Name        | Description (see script for further details)
+| -------------------------------- | --------------------------------
+| POPULATE_RELEASE_CURL_FAIL       | Designate how to handle curl failures. This can be one of `fail`, `none`, and `report` (default).
+| POPULATE_RELEASE_DEBUG           | Enable debug verbosity, any non-empty string enables this.
+| POPULATE_RELEASE_DESTINATION     | Destination parent directory.
+| POPULATE_RELEASE_FILE_REUSE      | Enable re-using existing JSON files without GET fetching, any non-empty string enables this.
+| POPULATE_RELEASE_FILES           | The name of space separated JSON files, such as `install.json` and `eureka-platform.json` to GET fetch and store locally for processing.
+| POPULATE_RELEASE_FLOWER          | The Flower release name, such as `quesnelia` or `snapshot`.
+| POPULATE_RELEASE_REGISTRY        | The URL to GET the module descriptor from for some specific module version.
+| POPULATE_RELEASE_REPOSITORY      | The raw GitHub repository URL to fetch from (but without the URL parts after the repository name).
+| POPULATE_RELEASE_REPOSITORY_PART | The part of the GitHub repository URL specifying the tag, branch, or hash (but without either the specific tag/branch name or the file path).
+| POPULATE_RELEASE_TAG             | The GitHub release tag, such as `R1-2024-csp-9`.
 
 View the documentation within the `populate_release.sh` script for further details on how to operate this script.
 
 Example usage:
 ```shell
-bash script/populate_release.sh R1-2024-csp-9 quesnelia
+POPULATE_RELEASE_FLOWER="quesnelia" POPULATE_RELEASE_TAG="R1-2024-csp-9" bash script/populate_release.sh
 ```
 
 _Make sure to manually delete any already downloaded JSON files to avoid accidentally including the wrong dependencies for some flower release when executing this script for multiple flower releases._
-
-
-### Populate Node
-
-The **Populate Node** is a supplementary script to the **Populate Release**.
-
-The **Populate Release** script operates based on existing pre-generated install JSON files.
-The **Populate Node** script operates based on generating the install JSON files using the **FOLIO NPM Registry** (or whichever registry is configured via the `~/.yarnrc` file).
-
-The install JSON file by default is named `npm.json` by default to prevent confusing it with the other install JSON files, such as `install.json` and `eureka-platform.json`.
-This `npm.json` file is re-created on every run of this script.
-
-The currently implementation of this script limits the packages being operated on to those prefixed with `@folio/` in their package name.
-
-This is intended to handle the small number of packages that are known to not be available directly in the **FOLIO Registry**, namely `@folio/authorization-policies` and `@folio/authorization-roles`.
-
-Example usage:
-```shell
-bash script/populate_node.sh
-```
 
 
 #### Populate via Branches and Commit Hashes
@@ -116,12 +144,64 @@ The value must be set to an empty string to use a specific commit hash instead o
 
 Example branch name usage:
 ```shell
-POPULATE_RELEASE_REPOSITORY_PART="heads" bash script/populate_release.sh snapshot snapshot
+POPULATE_RELEASE_REPOSITORY_PART="heads" POPULATE_RELEASE_FLOWER="snapshot" POPULATE_RELEASE_TAG="snapshot" bash script/populate_release.sh
 ```
 
 Example commit hash usage:
 ```shell
-POPULATE_RELEASE_REPOSITORY_PART="" bash script/populate_release.sh fe7223e040d5d024f3f4961a3bc324d99a6fe7f5 aggies
+POPULATE_RELEASE_REPOSITORY_PART="" POPULATE_RELEASE_FLOWER="aggies" POPULATE_RELEASE_TAG="fe7223e040d5d024f3f4961a3bc324d99a6fe7f5" bash script/populate_release.sh
+```
+
+
+### Populate Node
+
+The **Populate Node** is a supplementary script to the **Populate Release**.
+
+The **Populate Release** script operates based on existing pre-generated install JSON files.
+The **Populate Node** script operates based on generating the install JSON files using the **FOLIO NPM Registry** (or whichever registry is configured via the `~/.yarnrc` file).
+
+The install JSON file by default is named `npm.json` by default to prevent confusing it with the other install JSON files, such as `install.json` and `eureka-platform.json`.
+This `npm.json` file is re-created on every run of this script.
+
+The current implementation of this script limits the packages being operated on to those prefixed with `@folio/` in their package name.
+
+This is intended to handle the small number of packages that are known to not be available directly in the **FOLIO Registry**, namely `@folio/authorization-policies` and `@folio/authorization-roles`.
+
+| Environment Variable Name        | Description (see script for further details)
+| -------------------------------- | --------------------------------
+| POPULATE_NODE_DEBUG              | Enable debug verbosity, any non-empty string enables this.
+| POPULATE_NODE_DESTINATION        | Destination directory the release files are stored in (this defaults to `${PWD}/release/snapshot`).
+| POPULATE_NODE_NPM_DIR            | Designate a directory where the NPM JSON file is located (this defaults to `${PWD}`).
+| POPULATE_NODE_NPM_FILE           | The name of the NPM JSON file used to hold the generated projects and versions.
+| POPULATE_NODE_PROJECTS           | Designate the (space-separated) projects to operate on (specifying this overrides the default).
+| POPULATE_NODE_SKIP_BAD           | Skip projects that fail to fetch and build instead of aborting the script, any non-empty string enables this.
+| POPULATE_NODE_WORKSPACE          | Designate a workspace directory to use (This directory must already have a `package.json` workspace file).
+
+View the documentation within the `populate_node.sh` script for further details on how to operate this script.
+
+Example usage:
+```shell
+POPULATE_NODE_WORKSPACE="/path/to/workspace" bash script/populate_node.sh
+```
+
+
+### Synchronize Snapshot
+
+The **Synchronize Snapshot** script identifies whether or no changes are detected and preforms the necessary `git` operations to push those changes to an upstream repository.
+
+| Environment Variable Name        | Description (see script for further details)
+| -------------------------------- | --------------------------------
+| SYNC_SNAPSHOT_DEBUG              | Enable debug verbosity, any non-empty string enables this.
+| SYNC_SNAPSHOT_MESSAGE            | Specify a custom message to use for the commit.
+| SYNC_SNAPSHOT_PATH               | Designate a path in which to analyze (default is an empty string, which means current directory).
+| SYNC_SNAPSHOT_RESULT             | The file name to write the results of this script to.
+| SYNC_SNAPSHOT_SIGN               | Set to "yes" to explicitly sign, set to "no" to explicitly not sign, and do not set (or set to empty string) to use user-space default.
+
+View the documentation within the `synchronize_snapshot.sh` script for further details on how to operate this script.
+
+Example usage:
+```shell
+SYNC_SNAPSHOT_MESSAGE="Completed the snapshot synchronization." bash script/synchronize_snapshot.sh
 ```
 
 
@@ -129,6 +209,7 @@ POPULATE_RELEASE_REPOSITORY_PART="" bash script/populate_release.sh fe7223e040d5
 
 This repository utilizes GitHub Workflows to perform Continuous Integration and Continuous Delivery (CI/CD).
 The default configuration relies on `self-hosted` runners.
+
 _The `self-hosted` runners may easily be changed to something like `ubuntu-latest` and should work, in general._
 
 The GitHub Workflows are expected to clean up their working directory due to the nature of `self-hosted` runners.
@@ -148,7 +229,7 @@ These input variables are available both as input variables for event triggers a
 | `script_branch`         | string    | The name of the branch containing the scripts, such as `master`.
 
 
-### Build GitHub Pages
+### Build GitHub Pages Workflow
 
 This GitHub Workflow loads existing, pre-generated, FOLIO module descriptors and deploys the files on the **GitHub Pages** for this repository.
 
@@ -156,7 +237,7 @@ The deployment process utilizes GitHub Artifacts.
 These artifacts may be temporarily downloaded via the GitHub Workflow Action view and are available as per GitHub's retention policies.
 
 
-### Synchronize Snapshot
+### Synchronize Snapshot Workflow
 
 This GitHub Workflow loads the latest releases from some pre-configured `install.json` file, commits the changes, and pushes the changes to the GitHub repository registry branch.
 Commits made by this Workflow utilize the default GitHub Actions Bot (`41898282+github-actions[bot]@users.noreply.github.com`).
@@ -166,4 +247,115 @@ This only happens if changes are detected.
 Should something go wrong while calling the **Build GitHub Pages Workflow**, then the v must be manually called.
 This is because the changes during the synchronization are committed before the **Build GitHub Pages Workflow** is called.
 
-The **Synchronize Snapshot Workflow** is run using a cron-job like timer every day at 00:00:00 UTC.
+The **Synchronize Snapshot Workflow** is run using a cron job like timer every day at `00:00:00 UTC`.
+
+
+## Design and Methodology
+
+This repository is designed around the idea of avoiding re-creating existing CI/CD to a certain extent.
+The use of Bash scripting language over programming languages is done to keep the design simple and to focus on using existing tools.
+This repository is intended to automate part of the manual processes a user might have to perform when building and maintaining a FOLIO registry.
+The primary focus is on provide module descriptors, but there may be some cross-over functionality regarding application descriptors and other related CI/CD tasks.
+
+
+### Repository Branch Design
+
+There are two primary types of branches in use, called trunks.
+These two trunks, `master` and `snapshot`, operate from different fundamental concepts.
+
+The first trunk, `master`, is the most common trunk design.
+This houses scripts, workflows, documentation, and any other programmatic tool.
+Branches based on the `master` trunk are the traditional coding branches and is expected to be the primary fork and merge branch.
+There will be no release related content within this trunk beyond the scripts and tools used to operate on a release.
+Note that this "release" is not a release of the repository but instead is referring to FOLIO module, applications, or flower releases.
+
+The second trunk, `snapshot`, is a package release trunk design.
+This houses only descriptor files and other release related content.
+There are no scripts, documentation, or other non-release related content.
+This is maintained as a separate trunk to help maintain a clean repository structure.
+There will be a lot of automated commits entirely unrelated to the code itself.
+
+
+### GitHub Workflows Design
+
+The GitHub Workflows are designed to be dynamically toggled using a small number input variables.
+These Workflows provide input variables for selecting the individual branches to be selected.
+
+
+### Self-Hosted Design
+
+The GitHub Workflows are design to be operated within a self-hosted environment.
+This potentially gives the Workflow access to systems inside the self-hosted environment, such as Rancher and Kubernetes.
+
+A self-hosted system within Rancher might maintain state because a clean system might not be spun up and down for every single Workflow execution.
+This necessitates that the Workflows must manage potentially parallel state, such as creating distinct running instance sub-directories and the deletion of those directories on success.
+The standard behavior on failure is to not perform the directory clean up to help facilitate investigation of any problems.
+Should there be a lot of problems, the self-hosted runner may need either manual intervention or a custom process to clean up stale instance directories.
+
+
+### Separation of Concern Design
+
+A certain level of separation of concerns is used to structure the numerous scripts in this process.
+There may be some overlap or double duty in some scripts, but for the most part each script handles its process in isolation of other scripts.
+Many of the scripts will require the existence of files that are created by other scripts, but those files can be created through any means beyond just running other scripts.
+
+
+### Fail Forward Design
+
+A certain level of fail-forward behavior is supported by several scripts in order to ensure that problems with a single project or descriptor will not block or prevent the publishing of the entire set.
+This functionality is configurable via environment variables, but the Workflows enable this fail-forward behavior by default.
+
+
+### Scripting Design
+
+The scripts are design using functions in Bash.
+
+Each script is named using a few words to describe the general purpose of the script.
+The functions within the script, except special functions like `main`, are prefixed with either the script name or a shortened variation of the script name.
+The special case `main` function starts the program, acts as a holder of effective `global` local variables,
+
+Environment variables are prefixed with the full script name and are in all upper case.
+All environment variables are mapped to a `local` variable within the script at the `main` scope.
+Some amount of validation is performed on the environment variables.
+Most environment variables are treated as undefined when set to an empty string.
+There are some special cases where any empty string is explicitly needed and in such cases those variables are considered defined when empty (via the `-z` condition check).
+
+Special case `*_DEBUG*` variables are provided to help facilitate passing debug settings to the scripts.
+
+A custom `result` variable as an integer is used to help facility failure and success states.
+Most, if not all, functions pre-check this `result` variable for error state.
+This helps simplify the need for lots of conditional checks after each function call.
+The function calls can then be set side by side (technically above and below each other) without as many conditionals to make the script more readable.
+A special exception to these `result` checks all being in the functions include loops, such as `for` or `while`, where the loop needs to either be broken out of or continued.
+The `local` variables must be defined after the `result` check in functions for cases where the `result` variable is checked at the start of the function.
+
+A `*_handle_result` function is used as a standard naming for functions that check the `result` variable and print an error message.
+Errors are generally handled via the appropriate `*_handle_result` when a return code is involved.
+When there is no return code, then the `result` variable must be manually set and any desired printing must be directly performed.
+These functions are exception cases where the `local` variable must be defined at the start so that the `${?}` can be immediately processed before anything else could alter the value of `${?}`.
+
+A `*_print*` function is used for various types of printing that are conditionally printed, such as when debugging is enabled.
+
+A `*_load_environment` function is used in every script to perform processing of environment variables and command-line parameters passed to the script.
+These functions are expected to not check the error state on start so that they always run.
+The handling of the debug variables must be performed first to ensure error handling and debugging is enabled for the remainder of the function.
+
+The scripts are written in Bash, but are designed to increase the possibility of supporting other advanced shell interpreters, such as ZSH.
+The `${}` style is consistently used on all variables because some shell interpreters like ZSH are more fickle about such things.
+This practice also helps avoid inconsistencies in the styling when variables are combined side-by-side such that the `${}` is required.
+Double quotes are applied to all variables when spaces must be preserved, otherwise double quotes are avoided.
+The use of single quotes are limited to when variable substitution and other such behavior must explicitly be avoided in the string.
+
+The scripts are designed to control the verbosity using the `*_DEBUG*` environment variables.
+Exceptions to this are generally problematic programs like `jq` and `yarn`.
+
+It is encouraged to use `local` variables in a function to prevent those variables from being exposed at a higher level.
+If the parent function is managing some `local` variable, then that script is expected to not define a `local` for that variable.
+Many of the functions are design to expect some parent to have defined variables.
+Most functions, aside from the printing, error handling functions, and the load setting functions, do not expect variables passed to the function in a command-line style.
+Instead, `local` variables at a parent scope must be used.
+
+Each script is designed such that it can be executed stand alone on a local machine independent of the CI/CD.
+The Bash scripting environment and appropriately defined environment variables are still required as needed.
+
+Except for the `main` function, all functions are alphabetically ordered by name.

--- a/script/build_latest.sh
+++ b/script/build_latest.sh
@@ -9,15 +9,7 @@
 #   - jq
 #   - sed
 #
-#  Parameters:
-#    *) A list of install.json file names to parse (order sensitive).
-#
-#  Environment Variables:
-#    BUILD_LATEST_DEBUG:          Enable debug verbosity, any non-empty string enables this.
-#    BUILD_LATEST_FILES:          A list of files to build (applied before the command line arguments).
-#    BUILD_LATEST_IGNORE:         A path to a space and new line separated file (such as "setting/ignore.txt") representing module names to ignore.
-#    BUILD_LATEST_PATH:           The destination path to write to.
-#    BUILD_LATEST_SKIP_NOT_FOUND: Skip version files that are not found, any non-empty string enables this.
+# See the repository `README.md` for the listing of the environment variables and parameters.
 #
 # The BUILD_LATEST_DEBUG may be specifically set to "json" to include printing the JSON files.
 # The BUILD_LATEST_DEBUG may be specifically set to "json_only" to only print the JSON files, disabling all other debugging (does not pass -v).
@@ -29,7 +21,6 @@ main() {
   local debug=
   local debug_json=
   local files="install.json eureka-platform.json npm.json"
-  local ignore=
   local path="release/snapshot/"
 
   # Custom prefixes for debug and error.
@@ -96,45 +87,10 @@ build_latest_load_environment() {
     done
 
     file=
-  elif [[ ${#} -gt 0 ]] ; then
-
-    # Remove the defualts when there are no command line parameters and no BUILD_LATEST_FILES provided.
-    files=
-  fi
-
-  if [[ ${BUILD_LATEST_IGNORE} != "" ]] ; then
-    if [[ -f ${BUILD_LATEST_IGNORE} ]] ; then
-      file=$(cat ${BUILD_LATEST_IGNORE} | sed -e 's|^\s*||' -e 's|\s*$||')
-
-      if [[ ${file} != "" ]] ; then
-        for i in ${file} ; do
-          ignore="${ignore}${i} "
-        done
-      fi
-
-      file=
-    fi
   fi
 
   if [[ ${BUILD_LATEST_SKIP_NOT_FOUND} != "" ]] ; then
     let skip_not_found=1
-  fi
-
-  # Load files from the command line parameters.
-  if [[ ${#} -gt 0 ]] ; then
-    let i=1
-
-    while [[ ${i} -le ${#} ]] ; do
-
-      # Note: In ZSH this would instead be: file=${(P)i}.
-      file=$(echo ${!i} | sed -e 's|//*|/|g' -e 's|/*$||')
-
-      build_latest_print_debug "Using File: ${file}"
-
-      files="${files}${file} "
-
-      let i++
-    done
   fi
 
   if [[ ${BUILD_LATEST_PATH} != "" ]] ; then
@@ -157,13 +113,14 @@ build_latest_load_environment() {
 }
 
 build_latest_operate() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
   local file=
   local release=
   local releases=
   local i=
   local version=
-
-  if [[ ${result} -ne 0 ]] ; then return ; fi
 
   for file in ${files} ; do
 
@@ -177,12 +134,6 @@ build_latest_operate() {
       fi
 
       release=$(echo -n ${i} | sed -e "s|-SNAPSHOT*||" -e "s|-[^-]*$||" -e 's|"||g')
-
-      if [[ $(echo -n ${ignore} | grep -sho "\<${release}\>") != "" ]] ; then
-        build_latest_print_debug "Ignoring from ${file}: ${release}"
-
-        continue;
-      fi
 
       if [[ ! -f ${path}${i} ]] ; then
         if [[ ${skip_not_found} -ne 0 ]] ; then
@@ -219,10 +170,11 @@ build_latest_print_debug() {
 }
 
 build_latest_verify_files() {
-  local i=
-  local problems=
 
   if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  local i=
+  local problems=
 
   if [[ ${files} != "" ]] ; then
     for i in ${files} ; do

--- a/script/build_pages.sh
+++ b/script/build_pages.sh
@@ -17,15 +17,7 @@
 #  Parameters:
 #    *) All descriptor source directories to process. This script uses simple logic, be careful about sub-directory naming conflicts.
 #
-#  Environment Variables:
-#    BUILD_PAGES_BASE:           The base URL where the generated pages are stored.
-#    BUILD_PAGES_DEBUG:          Enable debug verbosity, any non-empty string enables this.
-#    BUILD_PAGES_IGNORE_INVALID: Ignore non-JSON files rather than fail, any non-empty string enables this.
-#    BUILD_PAGES_TEMPLATE_BACK:  The name of the back HTML template within the BUILD_PAGES_TEMPLATE_PATH directory.
-#    BUILD_PAGES_TEMPLATE_BASE:  The name of the base HTML template within the BUILD_PAGES_TEMPLATE_PATH directory.
-#    BUILD_PAGES_TEMPLATE_ITEM:  The name of the item HTML template within the BUILD_PAGES_TEMPLATE_PATH directory.
-#    BUILD_PAGES_TEMPLATE_PATH:  The path to the template directory containing the HTML template files.
-#    BUILD_PAGES_WORK:           A working directory used to create the gh-pages structure (all templates and files are added here).
+# See the repository `README.md` for the listing of the environment variables and parameters.
 #
 # The BUILD_PAGES_DEBUG may be specifically set to "json" to include printing the JSON files.
 # The BUILD_PAGES_DEBUG may be specifically set to "json_only" to only print the JSON files, disabling all other debugging (does not pass -v).
@@ -199,9 +191,10 @@ build_page_load_environment() {
 }
 
 build_page_operate() {
-  local indexes=
 
   if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  local indexes=
 
   build_page_operate_sources
 
@@ -214,11 +207,12 @@ build_page_operate() {
 }
 
 build_page_operate_sources() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
   local source=
   local j=
   local k=
-
-  if [[ ${result} -ne 0 ]] ; then return ; fi
 
   for i in ${sources} ; do
 
@@ -252,12 +246,13 @@ build_page_operate_sources() {
 }
 
 build_page_operate_sources_process_files() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
   local file=
   local files=
   local items=
   local k=
-
-  if [[ ${result} -ne 0 ]] ; then return ; fi
 
   for k in ${j}/* ; do
     file=$(basename ${k})
@@ -313,9 +308,10 @@ build_page_operate_sources_process_files_copy_file() {
 }
 
 build_page_operate_sources_process_files_template_item() {
-  local item=
 
   if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  local item=
 
   item=$(echo ${template_item_data} | sed -e "s|\<_REPLACE_LINK_\>|${source}/${file}|g" -e "s|\<_REPLACE_LINK_NAME_\>|${file}|g")
   items="${items}${item}_REPLACE_EOL_ "
@@ -344,12 +340,13 @@ build_page_operate_sources_process_files_verify_file() {
 }
 
 build_page_operate_sources_process_index() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
   local index=${1}
   local title=${2}
   local snippet=${3}
   local back=${4}
-
-  if [[ ${result} -ne 0 ]] ; then return ; fi
 
   if [[ $(echo ${snippet} | sed -e "s|\s||g") == "" ]] ; then
     snippet="There are no items available."
@@ -383,9 +380,10 @@ build_page_operate_sources_process_index() {
 }
 
 build_page_operate_sources_process_index_template_item() {
-  local item=
 
   if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  local item=
 
   item=$(echo ${template_item_data} | sed -e "s|\<_REPLACE_LINK_\>|${source}/|g" -e "s|\<_REPLACE_LINK_NAME_\>|${source}|g")
   indexes="${indexes}${item}_REPLACE_EOL_ "

--- a/script/populate_node.sh
+++ b/script/populate_node.sh
@@ -22,17 +22,7 @@
 #   - stripes-cli
 #   - yarn
 #
-#  Parameters:
-#    None.
-#
-#  Environment Variables:
-#    POPULATE_NODE_DEBUG:       Enable debug verbosity, any non-empty string enables this.
-#    POPULATE_NODE_DESTINATION: Destination directory the release files are stored in (this defaults to `${PWD}/release/snapshot`).
-#    POPULATE_NODE_NPM_DIR:     Designate a directory where the NPM JSON file is located (this defaults to `${PWD}`).
-#    POPULATE_NODE_NPM_FILE:    The name of the NPM JSON file used to hold the generated projects and versions.
-#    POPULATE_NODE_PROJECTS:    Designate the (space-separated) projects to operate on (specifying this overrides the default).
-#    POPULATE_NODE_SKIP_BAD:    Skip projects that fail to fetch and build instead of aborting the script, any non-empty string enables this.
-#    POPULATE_NODE_WORKSPACE:   Designate a workspace directory to use (This directory must already have a `package.json` workspace file).
+# See the repository `README.md` for the listing of the environment variables.
 #
 # The POPULATE_NODE_DEBUG may be specifically set to "json" to include printing the JSON files.
 # The POPULATE_NODE_DEBUG may be specifically set to "json_only" to only print the JSON files, disabling all other debugging (does not pass -v).
@@ -220,10 +210,11 @@ pop_node_process_projects_build_descriptor() {
 }
 
 pop_node_process_projects_copy_descriptor() {
-  local name=folio_${project}
-  local release="${destination}folio_${project_simple}-${version}"
 
   if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  local name=folio_${project}
+  local release="${destination}folio_${project_simple}-${version}"
 
   cp ${debug} module-descriptor.json ${release}
 
@@ -231,9 +222,10 @@ pop_node_process_projects_copy_descriptor() {
 }
 
 pop_node_process_projects_extract_version() {
-  local file="package.json"
 
   if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  local file="package.json"
 
   if [[ ! -f ${file} ]] ; then
     echo "${p_e}The ${file} file is either missing or not a valid regular file for: ${project} (simple: ${project_simple})."
@@ -284,7 +276,6 @@ pop_node_process_projects_into_workspace() {
 }
 
 pop_node_process_projects_update_npm_json() {
-  local json=
 
   if [[ ${result} -ne 0 ]] ; then return ; fi
 
@@ -295,7 +286,7 @@ pop_node_process_projects_update_npm_json() {
     echo "[{ \"id\": \"folio_${project_simple}-${version}\", \"action\": \"enable\" }]" > ${npm_dir}${npm_file}
   else
     # Work around JQ's problems with using the input as the output.
-    json=$(cat ${npm_dir}${npm_file})
+    local json=$(cat ${npm_dir}${npm_file})
 
     pop_node_print_debug "echo ${json} | jq \". |= . + [{ \\\"id\\\": \\\"folio_${project_simple}-${version}\\\", \\\"action\\\": \\\"enable\\\" }]\" > ${npm_dir}${npm_file}"
 
@@ -306,10 +297,11 @@ pop_node_process_projects_update_npm_json() {
 }
 
 pop_node_verify_files() {
-  local workspace_file=${workspace}package.json
-  local workspace_json="{ \"name\": \"workspace\", \"private\": true, \"version\": \"1.0.0\", \"workspaces\": [ \"*\" ], \"dependencies\": { } }"
 
   if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  local workspace_file=${workspace}package.json
+  local workspace_json="{ \"name\": \"workspace\", \"private\": true, \"version\": \"1.0.0\", \"workspaces\": [ \"*\" ], \"dependencies\": { } }"
 
   pop_node_verify_files_workspace
 
@@ -411,4 +403,4 @@ pop_node_verify_files_workspace_file_json() {
   pop_node_handle_result "Invalid workspace JSON file: ${workspace_file}"
 }
 
-main $*
+main ${*}

--- a/script/sync_snapshot.sh
+++ b/script/sync_snapshot.sh
@@ -7,15 +7,7 @@
 #   - grep
 #   - git
 #
-#  Parameters:
-#    1) (optional) A message to use for the Git commit.
-#
-#  Environment Variables:
-#    SYNC_SNAPSHOT_DEBUG:   Enable debug verbosity, any non-empty string enables this.
-#    SYNC_SNAPSHOT_MESSAGE: Specify a custom message to use for the commit.
-#    SYNC_SNAPSHOT_PATH:    Designate a path in which to analyze (default is an empty string, which means current directory).
-#    SYNC_SNAPSHOT_RESULT:  The file name to write the results of this script to.
-#    SYNC_SNAPSHOT_SIGN:    Set to "yes" to explicitly sign, set to "no" to explicitly not sign, and do not set (or set to empty string) to use user-space default.
+# See the repository `README.md` for the listing of the environment variables and parameters.
 #
 # The SYNC_SNAPSHOT_DEBUG may be specifically set to "git" to include printing the git commands.
 # The SYNC_SNAPSHOT_DEBUG may be specifically set to "git_only" to only print the git commands, disabling all other debugging (does not pass -v to git).
@@ -114,10 +106,6 @@ sync_snap_handle_result_git() {
 
 sync_snap_load_environment() {
 
-  if [[ ${1} != "" ]] ; then
-    message=${1}
-  fi
-
   if [[ ${SYNC_SNAPSHOT_DEBUG} != "" ]] ; then
     debug="-v"
 
@@ -173,4 +161,4 @@ sync_snap_push() {
   sync_snap_handle_result_git "pushing"
 }
 
-main $*
+main ${*}


### PR DESCRIPTION
Documentation Improvements:
- Add a navigation section due to how large the `README.md` file is.
- Add a note about the `npm-folioci` registry.
- Fix the location of the `Populate via Branches and Commit Hashes` section.
- Add a `Design and Methodology` section along with several sub-sections.
- Add missing `Synchronize Snapshot` section.
- Add `Workflow` to the name of the `GitHub Workflows` sub-sections to help avoid naming conflicts and potential confusion.
- Add the environment variables for the scripts using a table.
- Fix mistake where the `Example usage` shell script is incorrectly swapped with another section.
- Incidental spelling, styling, and grammar mistakes that were noticed are fixed.

Changes to Scripts:
- Relocate the declaration of the `local` variables to be after the `result` variable check (helps avoid adding variables to the stack when not needed).
- Add surrounding `${}` where they have been found to be missing.
- Remove the `ignore.txt` logic and `setting` directory.
- Remove the command line argument parameters support because this is no longer needed.
- Remove the environment variable documentation at the top of the scripts.

The `ignore.txt` logic ended up not being used and is likely no longer now that the "fail forward" logic is in place.
The final design ended up being entirely focused on environment variables.
This makes the command line arguments more costly to have and maintain so remove support for them entirely.

I don't want to document the environment variables in two different places.
It makes perfect sense to have the documentation of the environment variables with the scripts as that keeps them together.
However, the `README.md` is where most people will look and the advanced display features like a table help make reading this list easier.
Relocate the environment variables out of the scripts and into the `README.md` file.
Now the only place to manage them, for the most part, is in the `README.md` file.
More specific details are still provided in the individual scripts.