### PR TITLE
Add missing script and remove no longer needed environment variable.

### DIFF
--- a/.github/workflows/sync_snapshot.yml
+++ b/.github/workflows/sync_snapshot.yml
@@ -91,6 +91,7 @@ jobs:
           ref: ${{ inputs.script_branch || 'master' }}
           path: ${{steps.initialize_instance.outputs.instance}}/scripts
           sparse-checkout: |
+            script/build_latest.sh
             script/populate_node.sh
             script/populate_release.sh
             script/sync_snapshot.sh
@@ -119,7 +120,6 @@ jobs:
         working-directory: ${{steps.initialize_instance.outputs.instance}}/populate
         run: |
           BUILD_LATEST_DEBUG="${{ inputs.debug_mode }}" \
-          BUILD_LATEST_IGNORE="../scripts/setting/ignore.txt" \
           BUILD_LATEST_SKIP_NOT_FOUND="y" \
             bash ../scripts/script/build_latest.sh
 


### PR DESCRIPTION
The `build_latest.sh` script should be part of the sparse checkout in the `sync_snapshot.yml` file.

The `BUILD_LATEST_IGNORE` support removed and I failed to remove it from the Workflow fule as well.