### PR TITLE
Improve error reporting.

### DIFF
--- a/script/build_latest.sh
+++ b/script/build_latest.sh
@@ -43,7 +43,7 @@ build_latest_handle_result() {
   let result=${?}
 
   if [[ ${result} -ne 0 ]] ; then
-    echo "${1}"
+    echo "${p_e}${1} (system code ${result})."
     echo
   fi
 }
@@ -106,7 +106,7 @@ build_latest_load_environment() {
       else
         mkdir ${debug} -p ${path}
 
-        build_latest_handle_result "${p_e}The following path is could not be created: ${path} ."
+        build_latest_handle_result "The following path is could not be created: ${path}"
       fi
     fi
   fi

--- a/script/build_latest.sh
+++ b/script/build_latest.sh
@@ -106,7 +106,7 @@ build_latest_load_environment() {
       else
         mkdir ${debug} -p ${path}
 
-        build_latest_handle_result "The following path is could not be created: ${path}"
+        build_latest_handle_result "The following path could not be created: ${path}"
       fi
     fi
   fi

--- a/script/build_pages.sh
+++ b/script/build_pages.sh
@@ -68,7 +68,7 @@ build_page_handle_result() {
   let result=${?}
 
   if [[ ${result} -ne 0 ]] ; then
-    echo "${1}"
+    echo "${p_e}${1} (system code ${result})."
   fi
 }
 

--- a/script/populate_node.sh
+++ b/script/populate_node.sh
@@ -73,7 +73,7 @@ pop_node_handle_result() {
   let result=${?}
 
   if [[ ${result} -ne 0 ]] ; then
-    echo "${1}"
+    echo "${p_e}${1} (system code ${result})."
     echo
   fi
 }

--- a/script/populate_release.sh
+++ b/script/populate_release.sh
@@ -72,7 +72,7 @@ pop_rel_handle_result() {
   let result=${?}
 
   if [[ ${result} -ne 0 ]] ; then
-    echo "${1}"
+    echo "${p_e}${1} (system code ${result})."
     echo
   fi
 }
@@ -248,7 +248,7 @@ pop_rel_process_files_releases_curl() {
 
     curl -w '\n' ${curl_fail} ${debug} ${registry}${i} -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'cache-control: no-cache' -o ${destination}${flower}/${i}
 
-    pop_rel_handle_result "${p_e}Curl request failed (with system code ${?}) for: ${registry}${i} to ${destination}${flower}/${i}."
+    pop_rel_handle_result "Curl request failed for: ${registry}${i} to ${destination}${flower}/${i}"
 
     if [[ ${result} -ne 0 && ${fail_mode} == "report" ]] ; then
       # A 404 results in a 22 status code returned.
@@ -274,7 +274,7 @@ pop_rel_process_files_releases_prepare() {
   if [[ ! -d ${destination}${flower}/ ]] ; then
     mkdir ${debug} -p ${destination}${flower}/
 
-    pop_rel_handle_result "${p_e}Create directory failed (with system code ${?}) for destination: ${destination}${flower}/ ."
+    pop_rel_handle_result "Create directory failed for destination: ${destination}${flower}/"
   fi
 }
 
@@ -311,7 +311,7 @@ pop_rel_process_sources_prepare() {
   if [[ -e ${file} ]] ; then
     rm ${debug} -f ${file}
 
-    pop_rel_handle_result "${p_e}Create file failed (with system code ${?}) for install file: ${file} ."
+    pop_rel_handle_result "Create file failed for install file: ${file}"
   fi
 }
 
@@ -323,7 +323,7 @@ pop_rel_process_sources_curl() {
 
   curl -w '\n' ${curl_fail} ${debug} ${source} -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'cache-control: no-cache' -o ${file}
 
-  pop_rel_handle_result "${p_e}Curl request failed (with system code ${?}) for: ${source} ."
+  pop_rel_handle_result "Curl request failed for: ${source}"
 }
 
 main ${*}

--- a/script/sync_snapshot.sh
+++ b/script/sync_snapshot.sh
@@ -91,7 +91,7 @@ sync_snap_handle_result() {
   let result=${?}
 
   if [[ ${result} -ne 0 ]] ; then
-    echo "${1}"
+    echo "${p_e}${1} (system code ${result})."
     echo
   fi
 }
@@ -100,7 +100,7 @@ sync_snap_handle_result_git() {
   let result=${?}
 
   if [[ ${result} -ne 0 ]] ; then
-    echo "${p_e}Git failed (with system code ${result}) when ${1} changes."
+    echo "${p_e}Git failed when ${1} changes (system code ${result})."
   fi
 }
 
@@ -138,7 +138,7 @@ sync_snap_load_environment() {
   if [[ ${path} != "" ]] ; then
     cd ${path}
 
-    sync_snap_handle_result "${p_e}Failed (with system code ${?}) to change to path: ${path} ."
+    sync_snap_handle_result "Failed to change to path: ${path}"
   fi
 }
 


### PR DESCRIPTION
Have the system code always be reported when using the `*_handle_result()` functions. This avoids the need of having to add the `(with system code ${result})` in many places.

Always have the `*_handle_result()` functions provide utilize the `${p_e}` error. This avoids the need of having to add the `${p_e}` everywhere.

Add the period at the end of the `*_handle_result()` functions to properly complete the sentence. This avoids needing to add the `.` in every string passed to the `*_handle_result()` functions.