### PR TITLE
Add missing error message when printing error.

### DIFF
--- a/script/build_latest.sh
+++ b/script/build_latest.sh
@@ -151,7 +151,7 @@ build_latest_operate() {
 
       ln -vsf ${i} ${path}${release}-latest
 
-      build_latest_handle_result
+      build_latest_handle_result "Failed create symbolic link to '${i}' from '${path}${release}-latest'"
 
       if [[ ${result} -ne 0 ]] ; then return ; fi
     done


### PR DESCRIPTION
The error message itself is missing and so if this error gets handled then the message previously being printed is useless.