### PR TITLE
Redirect to normal output to ${null} in the specific case of fer-generate_yaml().

### DIFF
--- a/script/build_deployments.sh
+++ b/script/build_deployments.sh
@@ -778,7 +778,7 @@ build_depls_verify_json() {
   if [[ ${debug_json} != "" || ! -e ${null} ]] ; then
     echo ${code} | jq -M .
   else
-    echo ${code} | jq -M . 2> ${null}
+    echo ${code} | jq -M . >> ${null} 2>&1
   fi
 
   build_depls_handle_result "JSON Verification failed for ${name} file: ${file}"


### PR DESCRIPTION
The `jq` will print to stdout.

In the specific case of `build_depls_verify_json()`, that output is not needed and is not stored in a variable.
This results in the output printing to the screen, cluttering the screen.
This behavior should only be performed when debugging is enabled.