### PR TITLE
Redirect to normal output to ${null} in the specific case of fer-generate_yaml() (another).

### DIFF
--- a/script/build_module_discovery.sh
+++ b/script/build_module_discovery.sh
@@ -190,7 +190,7 @@ build_mod_disc_verify_json() {
     if [[ ${debug_json} != "" || ! -e ${null} ]] ; then
       jq < ${file}
     else
-      jq < ${file} 2> ${null}
+      jq < ${file} >> ${null} 2>&1
     fi
 
     let result=${?}


### PR DESCRIPTION
This handles a second case where JSON verify is printing when printing is not needed.

The `jq` will print to stdout.
In the specific case of `build_depls_verify_json()`, that output is not needed and is not stored in a variable.
This results in the output printing to the screen, cluttering the screen.
This behavior should only be performed when debugging is enabled.