### PR TITLE
Empty array results in invalid length assignment.

### DIFF
--- a/script/build_deployments.sh
+++ b/script/build_deployments.sh
@@ -469,15 +469,22 @@ build_depls_expand_file_load_template_maps_pcre_load_total() {
   if [[ ${result} -ne 0 || ${pcre_json} == "" ]] ; then return ; fi
 
   local jq_length="length"
+  local result=
 
   # Prevent jq from printing JSON if ${null} exists when not debugging.
   if [[ ${debug_json} != "" || ! -e ${null} ]] ; then
-    let pcre_total=$(echo "${pcre_json}" | jq -r -M "${jq_length}")
+    result=$(echo "${pcre_json}" | jq -r -M "${jq_length}")
   else
-    let pcre_total=$(echo "${pcre_json}" | jq -r -M "${jq_length}" 2> ${null})
+    result=$(echo "${pcre_json}" | jq -r -M "${jq_length}" 2> ${null})
   fi
 
   build_depls_handle_result "Failed to load and parse PCRE total from maps file: ${maps_path}"
+
+  if [[ ${result} != "" && ${result} != "null" ]] ; then
+    let pcre_total=${result}
+  else
+    let pcre_total=0
+  fi
 }
 
 build_depls_expand_file_load_template_maps_pcre_load_value() {

--- a/script/build_launches.sh
+++ b/script/build_launches.sh
@@ -244,15 +244,22 @@ build_launches_build_launch_container_port_process_count() {
   if [[ ${result} -ne 0 ]] ; then return ; fi
 
   local jq_length="length"
+  local result=
 
   # Prevent jq from printing JSON if ${null} exists when not debugging.
   if [[ ${debug_json} != "" || ! -e ${null} ]] ; then
-    let total=$(echo ${field_value} | jq -M -r "${jq_length}")
+    result=$(echo ${field_value} | jq -M -r "${jq_length}")
   else
-    let total=$(echo ${field_value} | jq -M -r "${jq_length}" 2> ${null})
+    result=$(echo ${field_value} | jq -M -r "${jq_length}" 2> ${null})
   fi
 
   build_launches_handle_result "Failed to extract total ports from loaded field value '${value}' of ${input_file}"
+
+  if [[ ${result} != "" && ${result} != "null" ]] ; then
+    let total=${result}
+  else
+    let total=0
+  fi
 }
 
 build_launches_build_launch_container_port_process_join() {


### PR DESCRIPTION
Using the `let=` bash assignment directly on a `jq` response is not good. The `jq` will return either the string `null` or an empty string.

Using `let=` with a value of `null` produces an error.

Move the `let=` assignment to a condition that checks the response. If the `result` is either `null` or an empty string then explicitly set the value to `0`. Otherwise, assign the `result` as is using `let=`.