### PR TITLE
Improve bash security by locking down IFS changes.

### DIFF
--- a/script/build_deployments.sh
+++ b/script/build_deployments.sh
@@ -32,6 +32,7 @@
 #
 
 main() {
+  local IFS= # Protect IFS from security issue before anything is done.
   local app="apps"
   local debug=
   local debug_json=

--- a/script/build_latest.sh
+++ b/script/build_latest.sh
@@ -17,6 +17,7 @@
 #
 
 main() {
+  local IFS= # Protect IFS from security issue before anything is done.
   local debug=
   local debug_json=
   local files="install.json eureka-platform.json npm.json"

--- a/script/build_launches.sh
+++ b/script/build_launches.sh
@@ -19,6 +19,7 @@
 #
 
 main() {
+  local IFS= # Protect IFS from security issue before anything is done.
   local debug=
   local debug_json=
   local null="/dev/null"

--- a/script/build_location.sh
+++ b/script/build_location.sh
@@ -35,6 +35,7 @@
 #
 
 main() {
+  local IFS= # Protect IFS from security issue before anything is done.
   local debug=
   local debug_curl=
   local debug_json=

--- a/script/build_module_discovery.sh
+++ b/script/build_module_discovery.sh
@@ -18,6 +18,7 @@
 #
 
 main() {
+  local IFS= # Protect IFS from security issue before anything is done.
   local debug=
   local debug_json=
   local field="name"

--- a/script/build_pages.sh
+++ b/script/build_pages.sh
@@ -29,6 +29,7 @@
 #
 
 main() {
+  local IFS= # Protect IFS from security issue before anything is done.
   local base="/folio-module-descriptor-registry/"
   local debug=
   local debug_json=

--- a/script/populate_node.sh
+++ b/script/populate_node.sh
@@ -42,6 +42,7 @@
 #
 
 main() {
+  local IFS= # Protect IFS from security issue before anything is done.
   local debug=
   local debug_json=
   local debug_yarn="-s"

--- a/script/populate_release.sh
+++ b/script/populate_release.sh
@@ -35,6 +35,7 @@
 #
 
 main() {
+  local IFS= # Protect IFS from security issue before anything is done.
   local debug=
   local debug_curl=
   local debug_json=

--- a/script/sync_snapshot.sh
+++ b/script/sync_snapshot.sh
@@ -16,6 +16,7 @@
 #
 
 main() {
+  local IFS= # Protect IFS from security issue before anything is done.
   local debug=
   local debug_git=
   local path=


### PR DESCRIPTION
The `IFS` environment variable is a special variable that can be used to change how variable expansion works. This can be used to break scripts or even perform exploits.

Lock this down by clearing out `IFS` before operating anything in the script. A local variable scope is defined to prevent this change from bubbling up and affecting the callers environment.

Example script showing the behavior of `IFS`:

```shell
IFS=":"
echo ${PATH}
```

Paths are normally separated by a `:` but are not separated by a space ` `.