### PR TITLE
Fixes, clean up, and consistency improvements.

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -62,7 +62,7 @@ jobs:
       - id: create_dirs
         name: Clean and Create Working Directories
         env:
-          OUTPUT_INSTANCE: ${{steps.initialize_instance.outputs.instance}}
+          OUTPUT_INSTANCE: ${{ steps.initialize_instance.outputs.instance }}
         run: |
           rm -Rf "${OUTPUT_INSTANCE}"/{populate,scripts,work}
           mkdir -p "${OUTPUT_INSTANCE}"/{populate,scripts,work}
@@ -72,20 +72,20 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.registry_branch }}
-          path: ${{steps.initialize_instance.outputs.instance}}/populate
+          path: ${{ steps.initialize_instance.outputs.instance }}/populate
 
       - id: checkout_scripts
         name: Checkout Scripts
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.script_branch }}
-          path: ${{steps.initialize_instance.outputs.instance}}/scripts
+          path: ${{ steps.initialize_instance.outputs.instance }}/scripts
           sparse-checkout: |
             script/build_pages.sh
             template
 
       - name: Generate Directory Listings
-        working-directory: ${{steps.initialize_instance.outputs.instance}}/populate
+        working-directory: ${{ steps.initialize_instance.outputs.instance }}/populate
         env:
           BUILD_PAGES_DEBUG: ${{ inputs.debug_mode }}
           BUILD_PAGES_WORK: ../work
@@ -95,13 +95,13 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ${{steps.initialize_instance.outputs.instance}}/work
+          path: ${{ steps.initialize_instance.outputs.instance }}/work
 
       - id: clean_up
         name: Clean Up
-        working-directory: ${{steps.initialize_instance.outputs.instance}}
+        working-directory: ${{ steps.initialize_instance.outputs.instance }}
         env:
-          OUTPUT_INSTANCE: ${{steps.initialize_instance.outputs.instance}}
+          OUTPUT_INSTANCE: ${{ steps.initialize_instance.outputs.instance }}
         run: |
           cd ..
           rm -Rf "${OUTPUT_INSTANCE}"

--- a/.github/workflows/sync_snapshot.yml
+++ b/.github/workflows/sync_snapshot.yml
@@ -68,8 +68,8 @@ jobs:
       - id: create_dirs
         name: Clean and Create Working Directories
         run: |
-          rm -Rf ${{steps.initialize_instance.outputs.instance}}/{populate,scripts}
-          mkdir -p ${{steps.initialize_instance.outputs.instance}}/{populate,scripts}
+          rm -Rf ${{ steps.initialize_instance.outputs.instance }}/{populate,scripts}
+          mkdir -p ${{ steps.initialize_instance.outputs.instance }}/{populate,scripts}
 
       - id: assure_stripes
         name: Assure Stripes
@@ -82,14 +82,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.registry_branch || 'snapshot' }}
-          path: ${{steps.initialize_instance.outputs.instance}}/populate
+          path: ${{ steps.initialize_instance.outputs.instance }}/populate
 
       - id: checkout_scripts
         name: Checkout Scripts
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.script_branch || 'master' }}
-          path: ${{steps.initialize_instance.outputs.instance}}/scripts
+          path: ${{ steps.initialize_instance.outputs.instance }}/scripts
           sparse-checkout: |
             script/build_latest.sh
             script/populate_node.sh
@@ -99,14 +99,14 @@ jobs:
 
       - id: populate_release
         name: Populate Release
-        working-directory: ${{steps.initialize_instance.outputs.instance}}/populate
+        working-directory: ${{ steps.initialize_instance.outputs.instance }}/populate
         run: |
           POPULATE_RELEASE_DEBUG="${{ inputs.debug_mode }}" \
             bash ../scripts/script/populate_release.sh
 
       - id: populate_node
         name: Populate Node
-        working-directory: ${{steps.initialize_instance.outputs.instance}}/populate
+        working-directory: ${{ steps.initialize_instance.outputs.instance }}/populate
         run: |
           POPULATE_NODE_DEBUG="${{ inputs.debug_mode }}" \
           POPULATE_NODE_DESTINATION="${{ steps.initialize_instance.outputs.top_dir }}${{steps.initialize_instance.outputs.instance}}/populate/release/snapshot/" \
@@ -117,7 +117,7 @@ jobs:
 
       - id: build_latest
         name: Build Latest Version Links
-        working-directory: ${{steps.initialize_instance.outputs.instance}}/populate
+        working-directory: ${{ steps.initialize_instance.outputs.instance }}/populate
         run: |
           BUILD_LATEST_DEBUG="${{ inputs.debug_mode }}" \
           BUILD_LATEST_SKIP_NOT_FOUND="y" \
@@ -125,7 +125,7 @@ jobs:
 
       - id: synchronize_snapshot
         name: Synchronize Snapshot
-        working-directory: ${{steps.initialize_instance.outputs.instance}}/populate
+        working-directory: ${{ steps.initialize_instance.outputs.instance }}/populate
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -136,10 +136,10 @@ jobs:
 
       - id: clean_up
         name: Clean Up
-        working-directory: ${{steps.initialize_instance.outputs.instance}}
+        working-directory: ${{ steps.initialize_instance.outputs.instance }}
         run: |
           cd ..
-          rm -Rf ${{steps.initialize_instance.outputs.instance}}
+          rm -Rf ${{ steps.initialize_instance.outputs.instance }}
 
   build_github_pages_workflow:
     name: Build Github Pages Workflow

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ View the documentation within the `build_launches.sh` script for further details
 
 Example usage:
 ```shell
-bash script/build_launches.sh
+bash BUILD_LAUNCHES_INPUT_PATH="template/launch/input/" script/build_launches.sh
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -435,14 +435,14 @@ The flower release name in relation to its release date designation (which maps 
 | `POPULATE_RELEASE_FLOWER`          | The Flower release name, such as `quesnelia` or `snapshot`.
 | `POPULATE_RELEASE_REGISTRY`        | The URL to GET the module descriptor from for some specific module version.
 | `POPULATE_RELEASE_REPOSITORY`      | The raw GitHub repository URL to fetch from (but without the URL parts after the repository name).
-| `POPULATE_RELEASE_REPOSITORY_PART` | The part of the GitHub repository URL specifying the tag, branch, or hash (but without either the specific tag/branch name or the file path).
+| `POPULATE_RELEASE_REPOSITORY_PART` | The part of the GitHub repository URL specifying the `tags`, `heads` for a branch (default), or an empty string for a commit hash (but without either the specific tag/branch name or the file path).
 | `POPULATE_RELEASE_TAG`             | The GitHub release tag, such as `R1-2024-csp-9`.
 
 View the documentation within the `populate_release.sh` script for further details on how to operate this script.
 
 Example usage:
 ```shell
-POPULATE_RELEASE_FLOWER="quesnelia" POPULATE_RELEASE_TAG="R1-2024-csp-9" bash script/populate_release.sh
+POPULATE_RELEASE_FLOWER="quesnelia" POPULATE_RELEASE_TAG="R1-2024-csp-9" POPULATE_RELEASE_REPOSITORY_PART="tags" bash script/populate_release.sh
 ```
 
 _Make sure to manually delete any already downloaded JSON files to avoid accidentally including the wrong dependencies for some flower release when executing this script for multiple flower releases._

--- a/script/build_application_descriptor.sh
+++ b/script/build_application_descriptor.sh
@@ -87,6 +87,7 @@ build_app_desc_build() {
 
   if [[ ${result} -ne 0 ]] ; then return ; fi
 
+  echo
   echo "Done: Application Descriptor JSON built: ${output_path_json} ."
 }
 
@@ -165,9 +166,9 @@ build_app_desc_build_write() {
 
   # Prevent jq from printing JSON if ${null} exists when not debugging.
   if [[ ${debug_json} != "" || ! -e ${null} ]] ; then
-    echo "${json}" | jq . > ${output_path_json}
+    jq . > ${output_path_json} <<< ${json}
   else
-    echo "${json}" | jq . > ${output_path_json} 2> ${null}
+    jq . > ${output_path_json} <<< ${json} 2> ${null}
   fi
 
   build_app_desc_handle_result "Failed to write to the output JSON file: ${output_path_json}"

--- a/script/build_deployments.sh
+++ b/script/build_deployments.sh
@@ -475,19 +475,19 @@ build_depls_expand_file_load_template_maps_pcre_load_total() {
   if [[ ${result} -ne 0 || ${pcre_json} == "" ]] ; then return ; fi
 
   local jq_length="length"
-  local result=
+  local data=
 
   # Prevent jq from printing JSON if ${null} exists when not debugging.
   if [[ ${debug_json} != "" || ! -e ${null} ]] ; then
-    result=$(jq -r -M "${jq_length}" <<< ${pcre_json})
+    data=$(jq -r -M "${jq_length}" <<< ${pcre_json})
   else
-    result=$(jq -r -M "${jq_length}" <<< ${pcre_json} 2> ${null})
+    data=$(jq -r -M "${jq_length}" <<< ${pcre_json} 2> ${null})
   fi
 
   build_depls_handle_result "Failed to load and parse PCRE total from maps file: ${maps_path}"
 
-  if [[ ${result} != "" && ${result} != "null" ]] ; then
-    let pcre_total=${result}
+  if [[ ${data} != "" && ${data} != "null" ]] ; then
+    let pcre_total=${data}
   else
     let pcre_total=0
   fi

--- a/script/build_deployments.sh
+++ b/script/build_deployments.sh
@@ -157,6 +157,11 @@ build_depls_combine() {
 
   # Always delete temporary JSON file.
   rm -f ${temp}
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  echo
+  echo "Done: Deployment JSON files are built."
 }
 
 build_depls_combine_append() {
@@ -352,9 +357,9 @@ build_depls_expand_file_load_template_combine() {
   else
     # Prevent jq from printing JSON if ${null} exists when not debugging.
     if [[ ${debug_json} != "" || ! -e ${null} ]] ; then
-      deploy=$(echo "${deploy_base} ${deploy_specific}" | jq -s -M "${jq_merge_join}")
+      deploy=$(jq -s -M "${jq_merge_join}" <<< "${deploy_base} ${deploy_specific}")
     else
-      deploy=$(echo "${deploy_base} ${deploy_specific}" | jq -s -M "${jq_merge_join}" 2> ${null})
+      deploy=$(jq -s -M "${jq_merge_join}" <<< "${deploy_base} ${deploy_specific}" 2> ${null})
     fi
 
     build_depls_handle_result "Failed to merge ${input_path_main}${name}.json and ${input_path_specific}${name}.json files"
@@ -457,9 +462,9 @@ build_depls_expand_file_load_template_maps_pcre_load_query() {
 
   # Prevent jq from printing JSON if ${null} exists when not debugging.
   if [[ ${debug_json} != "" || ! -e ${null} ]] ; then
-    pcre_query=$(echo "${pcre_json}" | jq -r -M "${jq_key_at_index}")
+    pcre_query=$(jq -r -M "${jq_key_at_index}" <<< ${pcre_json})
   else
-    pcre_query=$(echo "${pcre_json}" | jq -r -M "${jq_key_at_index}" 2> ${null})
+    pcre_query=$(jq -r -M "${jq_key_at_index}" <<< ${pcre_json} 2> ${null})
   fi
 
   build_depls_handle_result "Failed to load PCRE key index ${i} from maps file: ${maps_path}"
@@ -474,9 +479,9 @@ build_depls_expand_file_load_template_maps_pcre_load_total() {
 
   # Prevent jq from printing JSON if ${null} exists when not debugging.
   if [[ ${debug_json} != "" || ! -e ${null} ]] ; then
-    result=$(echo "${pcre_json}" | jq -r -M "${jq_length}")
+    result=$(jq -r -M "${jq_length}" <<< ${pcre_json})
   else
-    result=$(echo "${pcre_json}" | jq -r -M "${jq_length}" 2> ${null})
+    result=$(jq -r -M "${jq_length}" <<< ${pcre_json} 2> ${null})
   fi
 
   build_depls_handle_result "Failed to load and parse PCRE total from maps file: ${maps_path}"
@@ -498,9 +503,9 @@ build_depls_expand_file_load_template_maps_pcre_load_value() {
 
   # Prevent jq from printing JSON if ${null} exists when not debugging.
   if [[ ${debug_json} != "" || ! -e ${null} ]] ; then
-    pcre_value=$(echo "${pcre_json}" | jq -r -M "${jq_value_at_key}")
+    pcre_value=$(jq -r -M "${jq_value_at_key}" <<< ${pcre_json})
   else
-    pcre_value=$(echo "${pcre_json}" | jq -r -M "${jq_value_at_key}" 2> ${null})
+    pcre_value=$(jq -r -M "${jq_value_at_key}" <<< ${pcre_json} 2> ${null})
   fi
 
   build_depls_handle_result "Failed to load value for PCRE key '${pcre_query}' '${key}' from maps file: ${maps_path}"
@@ -708,9 +713,9 @@ build_depls_expand_variables() {
 
   # Prevent jq from printing JSON if ${null} exists when not debugging.
   if [[ ${debug_json} != "" || ! -e ${null} ]] ; then
-    data=$(echo ${data} | jq --argjson vars "${json_vars}" --argjson names "${jq_names}" "${jq_instruct}")
+    data=$(jq --argjson vars "${json_vars}" --argjson names "${jq_names}" "${jq_instruct}" <<< ${data})
   else
-    data=$(echo ${data} | jq --argjson vars "${json_vars}" --argjson names "${jq_names}" "${jq_instruct}" 2> ${null})
+    data=$(jq --argjson vars "${json_vars}" --argjson names "${jq_names}" "${jq_instruct}" <<< ${data} 2> ${null})
   fi
 
   build_depls_handle_result "Failed to expand ${what} into ${output}"
@@ -1024,9 +1029,9 @@ build_depls_load_json_discovery_names() {
 
   # Prevent jq from printing JSON if ${null} exists when not debugging.
   if [[ ${debug_json} != "" || ! -e ${null} ]] ; then
-    discovery_names=$(echo ${discovery_data} | jq -r -M "${jq_select_names}")
+    discovery_names=$(jq -r -M "${jq_select_names}" <<< ${discovery_data})
   else
-    discovery_names=$(echo ${discovery_data} | jq -r -M "${jq_select_names}" 2> ${null})
+    discovery_names=$(jq -r -M "${jq_select_names}" <<< ${discovery_data} 2> ${null})
   fi
 
   build_depls_handle_result "Failed to load Discovery Module names from \$BUILD_DEPLOY_DISCOVERY: ${file}"
@@ -1048,9 +1053,9 @@ build_depls_load_merge() {
 
     # Prevent jq from printing JSON if ${null} exists when not debugging.
     if [[ ${debug_json} != "" || ! -e ${null} ]] ; then
-      data=$(echo "${with} $(< ${file})" | jq -M -s "${jq_merge_replace}")
+      data=$(jq -M -s "${jq_merge_replace}" <<< "${with} $(< ${file})")
     else
-      data=$(echo "${with} $(< ${file})" | jq -M -s "${jq_merge_replace}" 2> ${null})
+      data=$(jq -M -s "${jq_merge_replace}" <<< "${with} $(< ${file})" 2> ${null})
     fi
 
     build_depls_handle_result "Failed to combine loaded template variables data with ${target} variables from ${file}"
@@ -1233,9 +1238,9 @@ build_depls_verify_json() {
 
   # Prevent jq from printing JSON if ${null} exists when not debugging.
   if [[ ${debug_json} != "" || ! -e ${null} ]] ; then
-    echo ${code} | jq -M .
+    jq -M . <<< ${code}
   else
-    echo ${code} | jq -M . >> ${null} 2>&1
+    jq -M . <<< ${code} >> ${null} 2>&1
   fi
 
   build_depls_handle_result "JSON Verification failed for ${name} file: ${file}"
@@ -1248,8 +1253,8 @@ build_depls_verify_name() {
   local name=${1}
   local describe=${2}
 
-  if [[ $(echo ${name} | grep -sho '[/\]') != "" ]] ; then
-    echo "${p_e}The ${describe} '${name}' may not contain forward or backward slashes."
+  if [[ $(echo -n ${name} | grep -sho "[/\\\"\']") != "" ]] ; then
+    echo "${p_e}The ${describe} must not contain '/', '\', ''', or '\"' characters: ${name} ."
 
     let result=1
   fi

--- a/script/build_deployments.sh
+++ b/script/build_deployments.sh
@@ -486,7 +486,7 @@ build_depls_expand_file_load_template_maps_pcre_load_total() {
 
   build_depls_handle_result "Failed to load and parse PCRE total from maps file: ${maps_path}"
 
-  if [[ ${data} != "" && ${data} != "null" ]] ; then
+  if [[ ${result} -eq 0 && ${data} != "" && ${data} != "null" ]] ; then
     let pcre_total=${data}
   else
     let pcre_total=0
@@ -526,6 +526,8 @@ build_depls_expand_file_load_template_maps_pcre_match_query() {
 
     alt_deploy_name="${pcre_value_deploy}"
     alt_service_name="${pcre_value_service}"
+  else
+    let matched=0
   fi
 
   build_depls_handle_result "Failed to operate PCRE query '${pcre_query}' for deploy value '${pcre_value_deploy}' and service value '${pcre_value_service}' from maps file: ${maps_path}"

--- a/script/build_latest.sh
+++ b/script/build_latest.sh
@@ -137,7 +137,7 @@ build_latest_operate() {
         continue
       fi
 
-      release=$(echo -n ${i} | sed -e "s|-SNAPSHOT*||" -e "s|-[^-]*$||" -e 's|"||g')
+      release=$(echo -n ${i} | sed -e "s|-SNAPSHOT*||" -e "s|-[^-]*$||")
 
       if [[ ! -f ${path}${i} ]] ; then
         if [[ ${skip_not_found} -ne 0 ]] ; then
@@ -161,6 +161,7 @@ build_latest_operate() {
     done
   done
 
+  echo
   echo "Done: Latest versions are built."
 }
 

--- a/script/build_launches.sh
+++ b/script/build_launches.sh
@@ -247,19 +247,19 @@ build_launches_build_launch_container_port_process_count() {
   if [[ ${result} -ne 0 ]] ; then return ; fi
 
   local jq_length="length"
-  local result=
+  local data=
 
   # Prevent jq from printing JSON if ${null} exists when not debugging.
   if [[ ${debug_json} != "" || ! -e ${null} ]] ; then
-    result=$(jq -M -r "${jq_length}" <<< ${field_value})
+    data=$(jq -M -r "${jq_length}" <<< ${field_value})
   else
-    result=$(jq -M -r "${jq_length}" <<< ${field_value} 2> ${null})
+    data=$(jq -M -r "${jq_length}" <<< ${field_value} 2> ${null})
   fi
 
   build_launches_handle_result "Failed to extract total ports from loaded field value '${value}' of ${input_file}"
 
-  if [[ ${result} != "" && ${result} != "null" ]] ; then
-    let total=${result}
+  if [[ ${data} != "" && ${data} != "null" ]] ; then
+    let total=${data}
   else
     let total=0
   fi

--- a/script/build_launches.sh
+++ b/script/build_launches.sh
@@ -258,7 +258,7 @@ build_launches_build_launch_container_port_process_count() {
 
   build_launches_handle_result "Failed to extract total ports from loaded field value '${value}' of ${input_file}"
 
-  if [[ ${data} != "" && ${data} != "null" ]] ; then
+  if [[ ${result} -eq 0 && ${data} != "" && ${data} != "null" ]] ; then
     let total=${data}
   else
     let total=0

--- a/script/build_location.sh
+++ b/script/build_location.sh
@@ -38,6 +38,7 @@ main() {
   local IFS=$' \t\n' # Protect IFS from security issue before anything is done.
   local debug=
   local debug_curl=
+  local debug_curl_silent="-s"
   local debug_json=
   local delay="0.3s"
   local destination="location/"
@@ -98,9 +99,11 @@ build_location_load_environment() {
 
     if [[ $(echo ${BUILD_LOCATION_DEBUG} | grep -sho "^\s*curl\s*$") != "" ]] ; then
       debug_curl="-v"
+      debug_curl_silent=
     elif [[ $(echo ${BUILD_LOCATION_DEBUG} | grep -sho "^\s*curl_only\s*$") != "" ]] ; then
       debug=
       debug_curl="-v"
+      debug_curl_silent=
     elif [[ $(echo ${BUILD_LOCATION_DEBUG} | grep -sho "^\s*json\s*$") != "" ]] ; then
       debug_json="y"
     elif [[ $(echo ${BUILD_LOCATION_DEBUG} | grep -sho "^\s*json_only\s*$") != "" ]] ; then
@@ -111,6 +114,7 @@ build_location_load_environment() {
     else
       if [[ $(echo ${BUILD_LOCATION_DEBUG} | grep -sho "\<curl\>") != "" ]] ; then
         debug_curl="-v"
+        debug_curl_silent=
       fi
 
       if [[ $(echo ${BUILD_LOCATION_DEBUG} | grep -sho "\<json\>") != "" ]] ; then
@@ -590,9 +594,9 @@ build_location_operate_login() {
 
   login_url="${auth_url}token?scope=repository:${repo}/${release}:pull${auth_registry}"
 
-  build_location_print_debug "Executing Login: curl ${debug_curl} '${login_url}'"
+  build_location_print_debug "Executing Login: curl ${debug_curl_silent} ${debug_curl} '${login_url}'"
 
-  response=$(curl ${debug_curl} "${login_url}")
+  response=$(curl ${debug_curl_silent} ${debug_curl} "${login_url}")
 
   build_location_handle_result "Curl request failed for repository '${repo}' and release '${release}' for: ${login_url}"
 
@@ -635,9 +639,9 @@ build_location_operate_request() {
     auth_header_redact="Authorization: Bearer (REDACTED)"
   fi
 
-  build_location_print_debug "Executing Load Manifest: curl ${debug_curl} -I -H '${auth_header_redact}' '${full_url}'"
+  build_location_print_debug "Executing Load Manifest: curl ${debug_curl_silent} ${debug_curl} -I -H '${auth_header_redact}' '${full_url}'"
 
-  request_manifest=$(curl ${debug_curl} -I -H "${auth_header_value}" ${full_url})
+  request_manifest=$(curl ${debug_curl_silent} ${debug_curl} -I -H "${auth_header_value}" ${full_url})
 
   build_location_handle_result "Curl request failed for repository '${repo}', release '${release}', and tag '${tag}' for: ${full_url}"
 

--- a/script/populate_node.sh
+++ b/script/populate_node.sh
@@ -204,6 +204,11 @@ pop_node_process_projects() {
 
   # Always pop the directory stack to return to the starting directory.
   popd
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  echo
+  echo "Done: Nodes are populated."
 }
 
 pop_node_process_projects_build_descriptor() {
@@ -299,9 +304,9 @@ pop_node_process_projects_update_npm_json() {
     # Work around JQ's problems with using the input as the output.
     local json=$(< ${npm_dir}${npm_file})
 
-    pop_node_print_debug "echo ${json} | jq \". |= . + [{ \\\"id\\\": \\\"folio_${project_simple}-${version}\\\", \\\"action\\\": \\\"enable\\\" }]\" > ${npm_dir}${npm_file}"
+    pop_node_print_debug "jq \". |= . + [{ \\\"id\\\": \\\"folio_${project_simple}-${version}\\\", \\\"action\\\": \\\"enable\\\" }]\" <<< ${json} > ${npm_dir}${npm_file}"
 
-    echo ${json} | jq ". |= . + [{ \"id\": \"folio_${project_simple}-${version}\", \"action\": \"enable\" }]" > ${npm_dir}${npm_file}
+    jq ". |= . + [{ \"id\": \"folio_${project_simple}-${version}\", \"action\": \"enable\" }]" <<< ${json} > ${npm_dir}${npm_file}
   fi
 
   pop_node_handle_result "Failed to add the version (${version}) for the project ${project} (simple: ${project_simple}) to: ${npm_dir}${npm_file}"

--- a/script/populate_release.sh
+++ b/script/populate_release.sh
@@ -163,7 +163,7 @@ pop_rel_load_environment() {
   fi
 
   if [[ ${POPULATE_RELEASE_REPOSITORY} != "" ]] ; then
-    repository=$(echo ${POPULATE_RELEASE_REPOSITORY} | sed -e 's|//*|/|g' -e 's|/*$|/|g')
+    repository=$(echo ${POPULATE_RELEASE_REPOSITORY} | sed -e -e 's|/*$|/|g')
   fi
 
   # May be empty, so use "-v" test rather than != "".
@@ -180,7 +180,7 @@ pop_rel_load_source() {
 
   if [[ ${result} -ne 0 ]] ; then return ; fi
 
-  source="$(echo ${repository} | sed -e 's|//*|/|g' -e 's|/*$|/|')${part}${tag}/${file}"
+  source="$(echo ${repository} | sed -e 's|/*$|/|')${part}${tag}/${file}"
 }
 
 pop_rel_print_curl_debug() {
@@ -237,7 +237,7 @@ pop_rel_process_files_releases_curl() {
     return
   fi
 
-  source="$(echo ${repository} | sed -e 's|//*|/|g' -e 's|/*$|/|')${part}${tag}/${file}"
+  source="$(echo ${repository} | sed -e 's|/*$|/|')${part}${tag}/${file}"
 
   for i in ${releases} ; do
 

--- a/script/populate_release.sh
+++ b/script/populate_release.sh
@@ -221,15 +221,18 @@ pop_rel_process_files() {
 
     if [[ ${result} -ne 0 ]] ; then break ; fi
   done
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  echo
+  echo "Done: Release is populated."
 }
 
 pop_rel_process_files_releases_curl() {
 
   if [[ ${result} -ne 0 ]] ; then return ; fi
 
-  local i=
   local release=
-  local version=
 
   if [[ ${releases} == "" ]] ; then
     echo "Done: No releases to fetch from."
@@ -239,16 +242,16 @@ pop_rel_process_files_releases_curl() {
 
   source="$(echo ${repository} | sed -e 's|/*$|/|')${part}${tag}/${file}"
 
-  for i in ${releases} ; do
+  for release in ${releases} ; do
 
     # Skip any files without the dash in the name used to provide a version.
-    if [[ $(echo ${i} | grep -sho '-') == "" ]] ; then
+    if [[ $(echo ${release} | grep -sho '-') == "" ]] ; then
       continue
     fi
 
-    if [[ -f ${destination}${flower}/${i} ]] ; then
+    if [[ -f ${destination}${flower}/${release} ]] ; then
       if [[ ${debug} != "" ]] ; then
-        echo "${p_d}Skipping existing Module Descriptor: ${destination}${flower}/${i} ."
+        echo "${p_d}Skipping existing Module Descriptor: ${destination}${flower}/${release} ."
         echo
       fi
 
@@ -256,17 +259,17 @@ pop_rel_process_files_releases_curl() {
     fi
 
     if [[ ${debug} != "" ]] ; then
-      echo "${p_d}Curl requesting Module Descriptor ${i} from: ${registry}${i} ."
+      echo "${p_d}Curl requesting Module Descriptor ${release} from: ${registry}${release} ."
       echo
     else
-      echo "Curl requesting Module Descriptor: ${i}."
+      echo "Curl requesting Module Descriptor: ${release}."
     fi
 
-    pop_rel_print_curl_debug "Executing Descriptor" "curl -w '\n' ${curl_fail} ${debug} ${registry}${i} -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'cache-control: no-cache' -o ${destination}${flower}/${i}"
+    pop_rel_print_curl_debug "Executing Descriptor" "curl -w '\n' ${curl_fail} ${debug} ${registry}${release} -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'cache-control: no-cache' -o ${destination}${flower}/${release}"
 
-    curl -w '\n' ${curl_fail} ${debug} ${registry}${i} -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'cache-control: no-cache' -o ${destination}${flower}/${i}
+    curl -w '\n' ${curl_fail} ${debug} ${registry}${release} -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'cache-control: no-cache' -o ${destination}${flower}/${release}
 
-    pop_rel_handle_result "Curl request failed for: ${registry}${i} to ${destination}${flower}/${i}"
+    pop_rel_handle_result "Curl request failed for: ${registry}${release} to ${destination}${flower}/${release}"
 
     if [[ ${result} -ne 0 && ${fail_mode} == "report" ]] ; then
       # A 404 results in a 22 status code returned.

--- a/script/populate_release.sh
+++ b/script/populate_release.sh
@@ -38,6 +38,7 @@ main() {
   local IFS=$' \t\n' # Protect IFS from security issue before anything is done.
   local debug=
   local debug_curl=
+  local debug_curl_silent="-s"
   local debug_json=
   local destination="release/"
   local curl_fail="--fail"
@@ -94,9 +95,11 @@ pop_rel_load_environment() {
 
     if [[ $(echo ${POPULATE_RELEASE_DEBUG} | grep -sho "^\s*curl\s*$") != "" ]] ; then
       debug_curl="y"
+      debug_curl_silent=
     elif [[ $(echo ${POPULATE_RELEASE_DEBUG} | grep -sho "^\s*curl_only\s*$") != "" ]] ; then
       debug=
       debug_curl="y"
+      debug_curl_silent=
     elif [[ $(echo ${POPULATE_RELEASE_DEBUG} | grep -sho "^\s*json\s*$") != "" ]] ; then
       debug_json="y"
     elif [[ $(echo ${POPULATE_RELEASE_DEBUG} | grep -sho "^\s*json_only\s*$") != "" ]] ; then
@@ -107,6 +110,7 @@ pop_rel_load_environment() {
     else
       if [[ $(echo ${POPULATE_RELEASE_DEBUG} | grep -sho "\<curl\>") != "" ]] ; then
         debug_curl="y"
+        debug_curl_silent=
       fi
 
       if [[ $(echo ${POPULATE_RELEASE_DEBUG} | grep -sho "\<json\>") != "" ]] ; then
@@ -265,9 +269,9 @@ pop_rel_process_files_releases_curl() {
       echo "Curl requesting Module Descriptor: ${release}."
     fi
 
-    pop_rel_print_curl_debug "Executing Descriptor" "curl -w '\n' ${curl_fail} ${debug} ${registry}${release} -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'cache-control: no-cache' -o ${destination}${flower}/${release}"
+    pop_rel_print_curl_debug "Executing Descriptor" "curl -w '\n' ${curl_fail} ${debug_curl_silent} ${debug_curl} ${registry}${release} -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'cache-control: no-cache' -o ${destination}${flower}/${release}"
 
-    curl -w '\n' ${curl_fail} ${debug} ${registry}${release} -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'cache-control: no-cache' -o ${destination}${flower}/${release}
+    curl -w '\n' ${curl_fail} ${debug_curl_silent} ${debug_curl} ${registry}${release} -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'cache-control: no-cache' -o ${destination}${flower}/${release}
 
     pop_rel_handle_result "Curl request failed for: ${registry}${release} to ${destination}${flower}/${release}"
 


### PR DESCRIPTION
Clean up styling practices for `${{ }}` variables.

Variable assignment is losing a '/' in 'https://' in `populate_release.sh`.
The sanitizers are too aggressive.
Do not sanitize the extra slashes in a URL to avoid causing a problem where the URL become `http:/` instead of `http://`.

Improve documentation regarding populate release repository part settings.

Fix consistency issues between the various scripts.

Improve variable checks by ensuring single and double quotes are not used to avoid potential problems with JSON.

Remove stale sed statements that strip out the double quotes.
These ended up not being needed anymore once the `-r` command (raw) was passed to `jq` (and `yq`).

Add missing documentation regarding sed dependency in `build_module_discovery.sh`.

The JSON in `build_module_discovery.sh` should not be directly written.
Instead, store everything inside a bash variable and then write at the end.
This change prevents incomplete JSON from being written should any error occur during processing.
The use of `jq` to write this final complete JSON results in validated JSON on write.

Update the verify output functions to accept a key name and value as parameters.

Calculate the totals using `jq` but do so by storing the `jq` result in a string value.
Only if jq succeeds and has a non-empty, non-"null", string should this be converted into an integer type.

Make sure all `jq` (and `yq`) calls use a variable for the command except for the case of `.`.

Use `<<<` instead of `echo "" |` to direct output to programs like `jq`.
This cleans the code up a little and also reduces some potential argument passing logic.
The `<<<` directly sends the data over whereas the `echo "" |` processes the string and then pipes it over.

Add more print messages.
Make sure scripts print a final done message on success.
Add some additional normal prints and debug prints to make the loop processing more apparent and less a mystery.

The `result` variable is exclusively used for the return status.
Do not override it with a local variable.

The launches now generate correctly again with this fix.

Only call `let=` assignment on success and always reset let value to 0 on failure.

Improve curl processing, utilizing -s/--silent.

This should reduce the amount of noise generated on the console when not explicitly running in curl debug mode.
Make sure the "-v" for curl debug mode is passed to curl rather than the normal debug mode (this behavior might change in the future after further consideration).

Fix directory creation and return status codes for build_launches.sh.
The `shopt -s lastpipe` must be added before the `find ... | while read ...` loop to force operating in the foreground rather than in some subshel
l.
Local variables do not bubble outside of subshells.
Make sure the output directory exists and if not, then create it.
Handle error as appropriate.
