### PR TITLE
Do not check return status of grep.

### DIFF
--- a/script/build_deployments.sh
+++ b/script/build_deployments.sh
@@ -530,10 +530,13 @@ build_depls_expand_file_load_template_maps_pcre_match_query() {
     let matched=0
   fi
 
-  let result=${?}
-  if [[ ${result} -eq 2 ]] ; then
+  if [[ ${?} -eq 2 ]] ; then
     echo "${p_e}Failed to operate PCRE query '${pcre_query}' for deploy value '${pcre_value_deploy}' and service value '${pcre_value_service}' from maps file: ${maps_path} (system code ${result})."
     echo
+
+    let result=1
+  else
+    let result=0
   fi
 }
 


### PR DESCRIPTION
The `grep` documentation states the following:
```
Exit status is 0 if any line is selected, 1 otherwise;
if any error occurs and -q is not given, the exit status is 2.
```

Therefore, an exist status of `1` is not an error.

Fix a false positive in `build_depls_expand_file_load_template_maps_pcre_match_query()`.