### PR TITLE
Document mkdir requirement and ensure app desc output path exists.

### DIFF
--- a/script/build_application_descriptor.sh
+++ b/script/build_application_descriptor.sh
@@ -15,6 +15,7 @@
 #   - date (optional, used if available)
 #   - grep
 #   - jq
+#   - mkdir
 #   - sed
 #
 # See the repository `README.md` for the listing of the environment variables and parameters.
@@ -335,7 +336,34 @@ build_app_desc_verify_files() {
     if [[ ${result} -ne 0 ]] ; then return ; fi
   done
 
+  build_app_desc_verify_directory "output path" ${output_path} create
   build_app_desc_verify_output "output file" ${output_path_json}
+}
+
+build_app_desc_verify_directory() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  local name=${1}
+  local path=${2}
+  local option=${3}
+
+  # Optionally attempt create the directory if it does not exist.
+  if [[ ${option} == "create" ]] ; then
+    if [[ ! -e ${path} ]] ; then
+      mkdir -p ${debug} ${path}
+
+      build_app_desc_handle_result "Failed to create the ${name} directory: ${path}"
+
+      if [[ ${result} -ne 0 ]] ; then return ; fi
+    fi
+  fi
+
+  if [[ ! -d ${path} ]] ; then
+    echo "${p_e}The ${name} is not a valid directory: ${path} ."
+
+    let result=1
+  fi
 }
 
 build_app_desc_verify_json() {

--- a/script/build_deployments.sh
+++ b/script/build_deployments.sh
@@ -6,6 +6,7 @@
 #   - bash
 #   - grep
 #   - jq
+#   - mkdir
 #   - sed
 #   - yq
 #

--- a/script/build_latest.sh
+++ b/script/build_latest.sh
@@ -6,6 +6,7 @@
 #   - bash
 #   - grep
 #   - jq
+#   - mkdir
 #   - sed
 #
 # See the repository `README.md` for the listing of the environment variables and parameters.

--- a/script/build_launches.sh
+++ b/script/build_launches.sh
@@ -9,6 +9,7 @@
 #   - find
 #   - grep
 #   - jq
+#   - mkdir
 #   - sed
 #   - sort
 #

--- a/script/build_location.sh
+++ b/script/build_location.sh
@@ -7,6 +7,7 @@
 #   - curl
 #   - grep
 #   - jq
+#   - mkdir
 #   - sed
 #   - sleep (This is not required if BUILD_LOCATION_DELAY is set to "0".)
 #

--- a/script/populate_node.sh
+++ b/script/populate_node.sh
@@ -19,6 +19,7 @@
 #   - cd
 #   - grep
 #   - jq
+#   - mkdir
 #   - sed
 #   - yarn
 #

--- a/script/populate_release.sh
+++ b/script/populate_release.sh
@@ -7,6 +7,7 @@
 #   - curl
 #   - grep
 #   - jq
+#   - mkdir
 #   - sed
 #
 # See the repository `README.md` for the listing of the environment variables and parameters.


### PR DESCRIPTION
The `mkdir` program is now added in the dependency lists.

The `build_application_descriptor.sh` script should attempt to create the output directory if it does not already exist. This copies over the code from `build_deployments.sh` for directory verification and creation.