### PR TITLE
Remove instance and version from selectors.

### DIFF
--- a/template/deploy/input/main/deployment.json
+++ b/template/deploy/input/main/deployment.json
@@ -19,9 +19,7 @@
       "matchLabels": {
         "app": "{global:app}",
         "app.kubernetes.io/name": "{name:}",
-        "app.kubernetes.io/instance": "{id:}",
         "app.kubernetes.io/part-of": "FOLIO",
-        "app.kubernetes.io/version": "{version:}",
         "environment": "scratch"
       }
     },

--- a/template/deploy/input/main/deployment_sidecar.json
+++ b/template/deploy/input/main/deployment_sidecar.json
@@ -19,9 +19,7 @@
       "matchLabels": {
         "app": "{global:app}",
         "app.kubernetes.io/name": "{name:}",
-        "app.kubernetes.io/instance": "{id:}",
         "app.kubernetes.io/part-of": "FOLIO",
-        "app.kubernetes.io/version": "{version:}",
         "environment": "scratch"
       }
     },

--- a/template/deploy/input/main/service.json
+++ b/template/deploy/input/main/service.json
@@ -29,9 +29,7 @@
     "selector": {
       "app": "{global:app}",
       "app.kubernetes.io/name": "{name:}",
-      "app.kubernetes.io/instance": "{id:}",
       "app.kubernetes.io/part-of": "FOLIO",
-      "app.kubernetes.io/version": "{version:}",
       "environment": "scratch"
     },
     "type": "ClusterIP"

--- a/template/deploy/input/main/service_sidecar.json
+++ b/template/deploy/input/main/service_sidecar.json
@@ -35,9 +35,7 @@
     "selector": {
       "app": "{global:app}",
       "app.kubernetes.io/name": "{name:}",
-      "app.kubernetes.io/instance": "{id:}",
       "app.kubernetes.io/part-of": "FOLIO",
-      "app.kubernetes.io/version": "{version:}",
       "environment": "scratch"
     },
     "type": "ClusterIP"

--- a/template/deploy/input/main/stateful_set.json
+++ b/template/deploy/input/main/stateful_set.json
@@ -19,9 +19,7 @@
       "matchLabels": {
         "app": "{global:app}",
         "app.kubernetes.io/name": "{name:}",
-        "app.kubernetes.io/instance": "{id:}",
         "app.kubernetes.io/part-of": "FOLIO",
-        "app.kubernetes.io/version": "{version:}",
         "environment": "scratch"
       }
     },


### PR DESCRIPTION
Changing the deployment to a new version will result in a new selector group with a new version and id.
The old version will stay up because it has a different selector.
Therefore, the selectors must not have the version (or the id).