### PR TITLE
Remove explicit namespace.

### DIFF
--- a/template/deploy/input/main/deployment.json
+++ b/template/deploy/input/main/deployment.json
@@ -10,8 +10,7 @@
       "app.kubernetes.io/version": "{version:}",
       "environment": "scratch"
     },
-    "name": "{name:}",
-    "namespace": "{global:namespace}"
+    "name": "{name:}"
   },
   "spec": {
     "replicas": 1,
@@ -37,8 +36,7 @@
           "app.kubernetes.io/part-of": "FOLIO",
           "app.kubernetes.io/version": "{version:}",
           "environment": "scratch"
-        },
-        "namespace": "{global:namespace}"
+        }
       },
       "spec": {
         "containers": [

--- a/template/deploy/input/main/deployment_sidecar.json
+++ b/template/deploy/input/main/deployment_sidecar.json
@@ -10,8 +10,7 @@
       "app.kubernetes.io/version": "{version:}",
       "environment": "scratch"
     },
-    "name": "{name:}",
-    "namespace": "{global:namespace}"
+    "name": "{name:}"
   },
   "spec": {
     "replicas": 1,
@@ -37,8 +36,7 @@
           "app.kubernetes.io/part-of": "FOLIO",
           "app.kubernetes.io/version": "{version:}",
           "environment": "scratch"
-        },
-        "namespace": "{global:namespace}"
+        }
       },
       "spec": {
         "containers": [

--- a/template/deploy/input/main/service.json
+++ b/template/deploy/input/main/service.json
@@ -10,8 +10,7 @@
       "app.kubernetes.io/version": "{version:}",
       "environment": "scratch"
     },
-    "name": "{name:}",
-    "namespace": "{global:namespace}"
+    "name": "{name:}"
   },
   "spec": {
     "ipFamilies": [

--- a/template/deploy/input/main/service_sidecar.json
+++ b/template/deploy/input/main/service_sidecar.json
@@ -10,8 +10,7 @@
       "app.kubernetes.io/version": "{version:}",
       "environment": "scratch"
     },
-    "name": "{name:}",
-    "namespace": "{global:namespace}"
+    "name": "{name:}"
   },
   "spec": {
     "ipFamilies": [

--- a/template/deploy/input/main/stateful_set.json
+++ b/template/deploy/input/main/stateful_set.json
@@ -10,8 +10,7 @@
       "app.kubernetes.io/version": "{version:}",
       "environment": "scratch"
     },
-    "name": "{name:}",
-    "namespace": "{global:namespace}"
+    "name": "{name:}"
   },
   "spec": {
     "replicas": 1,
@@ -35,8 +34,7 @@
           "app.kubernetes.io/part-of": "FOLIO",
           "app.kubernetes.io/version": "{version:}",
           "environment": "scratch"
-        },
-        "namespace": "{global:namespace}"
+        }
       },
       "spec": {
         "containers": [


### PR DESCRIPTION
The GitHubRepo Fleet configuration should define this rather than the manifest files.
This will allow the same manifest files to be used in different namespaces and clusters.