### PR TITLE
Implement Module and deployment descriptor generating script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+checkout
 eureka-platform.json
 install-extras.json
 install.json

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The [FOLIO Application Generator](folio-org/folio-application-generator) should 
     - [Build Latest](#build-latest)
     - [Build Launches](#build-launches)
     - [Build Location](#build-location)
+    - [Build Module Descriptors](#build-module-descriptors)
     - [Build Module Discovery](#build-module-discovery)
     - [Build Pages](#build-pages)
     - [Populate Node](#populate-node)
@@ -315,6 +316,117 @@ View the documentation within the `build_location.sh` script for further details
 Example usage:
 ```shell
 bash BUILD_LOCATION_LIMIT=100 BUILD_LOCATION_DELAY="0.3s" script/build_location.sh
+```
+
+
+### Build Module Descriptors
+
+The **Build Module Descriptors** script provides a way to build multiple **Deployment Descriptors** and **Module Descriptors** files.
+The purpose of this script is to act as a temporary helper tool for constructing the descriptors using only an `install.json` file for use in a legacy [OKAPI](https://github.com/folio-org/okapi/) environment.
+This approach has limitations, but these limitations are of little concern given that [OKAPI](https://github.com/folio-org/okapi/) is now considered a legacy application.
+
+The descriptors are first searched for at the `descriptors/` sub-directory in the root of the module sources.
+Should the descriptors not be found in the standard `descriptors/` sub-directory, then the first match found during a file search is used.
+These sources are checked out by this script and are automatically removed at the end of a successful operation.
+
+The non-UI modules are built using `sed` replacements to avoid the expensive process of building the descriptors through the normal mechanisms, such as `mvn package`
+The UI modules are built using `yarn run build-mod-descriptor`.
+
+There are two mapping structures used by several of the settings:
+  1. `exact`
+  2. `pcre`.
+
+The `exact` key object is used for matching the exact module name and has precedence over the `pcre` key object.
+The `pcre` key object is used for matching the module name using Perl Compatible Regular Expressions (PCRE).
+
+There are two JSON files in the `template/descriptor/` directory used by this script:
+  1. `replace.json`
+  2. `setting.json`
+
+The `replace.json` file provides a named set of objects.
+Each object contains a set of strings to match and replace in the appropriate descriptor template.
+There also exists the following special reserved names:
+  1. `all`: All strings are to be matched and replaced.
+  2. `none`: No strings are substituted (useful for pre-created descriptors).
+
+The `setting.json` file provides configuration settings for controlling how to build the descriptors.
+There are two main top-level keyed objects:
+  1. `operate`
+  2. `override`
+
+The `setting.json` `operate` key is used to map how to perform the building based based on the module name.
+This utilizes the `exact` and `pcre` mapping structure.
+The following keys within each `exact` and `pcre` mapping object are supported:
+  1. `method`
+  2. `type`
+
+The `operate` `method` provides two major ways to perform the building of the descriptor:
+  1. `jq`
+  2. `yarn`
+
+The `operate` `method` `jq` is intended to be used for non-UI modules.
+This method searches for `DeploymentDescriptor-template.json` and `ModuleDescriptor-template.json` and uses `jq` to construct the appropriate descriptor.
+The names of the template files may be changed using the `override` `descriptor` map.
+
+The `operate` `method` `yarn` is intended to be used for UI modules.
+This method executes the `yarn run build-mod-descriptor` command to build the descriptor.
+This does not perform the `yarn install` command to save on time and resources.
+
+The `operate` `type` provides the name of the find and replace map.
+The values are defined in the `replace.json` file or use one of the reserved names.
+
+The `setting.json` `override` key is used to override the standard behavior to handle special situations and supports the following keys:
+  1. `descriptor`
+  2. `omit`
+  3. `rename`
+
+The `override` `descriptor` is used to change the behavior of which descriptors to build or change the name of the source descriptors.
+This utilizes the `exact` and `pcre` mapping structure.
+The following keys within each `exact` and `pcre` mapping object are supported:
+  1. `discovery_name`
+  2. `module_name`
+  3. `use_discovery`
+  4. `use_module`
+
+Both the `discovery_name` and `module_name` for the `override` `descriptor` provide an alternative name to the default `DeploymentDescriptor-template.json` or `ModuleDescriptor-template.json`.
+
+Both the `use_discovery` and `use_module` for the `override` `descriptor` provide a way to `skip` building the deployment or module descriptor for a matching module.
+Any value other than `skip` will result in the normal building of the descriptor.
+
+The `override` `omit` is used to entirely skip a module.
+This utilizes the `exact` and `pcre` mapping structure.
+The following keys within each `exact` and `pcre` mapping object are supported:
+  1. `type`
+
+The `override` `omit` `type` is used to specify how to determine if the module is to be entirely skipped (omitted).
+The only value for `type` that is supported is `always`.
+
+The `override` `rename` is used to rename a module as it is described in the `install.json` to another form.
+This is particularly needed for UI modules whose names do not begin with `ui-`.
+This utilizes the `exact` and `pcre` mapping structure.
+The following keys within each `exact` and `pcre` mapping object are supported:
+  1. `to`
+
+The `override` `rename` `to` provides the new name of the module.
+This overridden name is not used for the purposes of the `exact` and `pcre` matching (which both utilize the original module name as described in the `install.json` file).
+
+| Environment Variable                       | Description (see script for further details)
+| ------------------------------------------ | --------------------------------
+| `BUILD_MOD_DESCRIPTORS_CHECKOUT_PATH`      | The path to clone the repositories.
+| `BUILD_MOD_DESCRIPTORS_DEBUG`              | Enable debug verbosity, any non-empty string enables this.
+| `BUILD_MOD_DESCRIPTORS_DEFAULT_BRANCH`     | Specify the default branch to checkout (usually either `main` or `master`).
+| `BUILD_MOD_DESCRIPTORS_DEFAULT_REPOSITORY` | The default repository URL prefix (usually a GitHub URL).
+| `BUILD_MOD_DESCRIPTORS_FILES`              | The input files to process (usually only `install.json`).
+| `BUILD_MOD_DESCRIPTORS_FLOWER`             | The Flower release name, such as `quesnelia` or `snapshot`.
+| `BUILD_MOD_DESCRIPTORS_INPUT_PATH`         | The directory containing the templates and settings.
+| `BUILD_MOD_DESCRIPTORS_OUTPUT_PATH`        | The output directory to save all build descriptors.
+| `BUILD_MOD_DESCRIPTORS_RESTRICT_TO`        | A list of module prefixes from the `install.json` files to limit the processing to.
+
+View the documentation within the `build_module_descriptors.sh` script for further details on how to operate this script.
+
+Example usage:
+```shell
+BUILD_MOD_DESCRIPTORS_FLOWER="quesnelia" BUILD_MOD_DESCRIPTORS_CHECKOUT_PATH="../checkout/" BUILD_MOD_DESCRIPTORS_INPUT_PATH="../input/" BUILD_MOD_DESCRIPTORS_OUTPUT_PATH="../output/" bash script/build_module_descriptors.sh
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ The UI modules are built using `yarn run build-mod-descriptor`.
 
 There are two mapping structures used by several of the settings:
   1. `exact`
-  2. `pcre`.
+  2. `pcre`
 
 The `exact` key object is used for matching the exact module name and has precedence over the `pcre` key object.
 The `pcre` key object is used for matching the module name using Perl Compatible Regular Expressions (PCRE).
@@ -361,7 +361,8 @@ The `setting.json` `operate` key is used to map how to perform the building base
 This utilizes the `exact` and `pcre` mapping structure.
 The following keys within each `exact` and `pcre` mapping object are supported:
   1. `method`
-  2. `type`
+  2. `repository`
+  3. `type`
 
 The `operate` `method` provides two major ways to perform the building of the descriptor:
   1. `jq`
@@ -377,6 +378,24 @@ This does not perform the `yarn install` command to save on time and resources.
 
 The `operate` `type` provides the name of the find and replace map.
 The values are defined in the `replace.json` file or use one of the reserved names.
+
+The `operate` `repository` provides a way to customize the repository using the following:
+  1. `branch`
+  2. `type`
+  3. `url`
+
+The `operate` `repository` `branch` provides a way to specify a custom branch when cloning a module.
+
+The `operate` `repository` `type` provides a way to control how the repository URL is to be processed and supports the following values:
+  1. `full`
+  2. `partial`
+
+When `operate` `repository` `type` is set to `full`, then the `operate` `repository` `url` represents the full URL, including the module.
+When `operate` `repository` `type` is set to `partial`, then the `operate` `repository` `url` represents the URL without the module.
+The default behavior, when no `type` is used is to use the default repository URL.
+In all cases, except for `full`, the module being processed is appended to the URL when cloning.
+
+The `operate` `repository` `url` provides a way to specify a custom base repository URL to use.
 
 The `setting.json` `override` key is used to override the standard behavior to handle special situations and supports the following keys:
   1. `descriptor`

--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ This approach has limitations, but these limitations are of little concern given
 The descriptors are first searched for at the `descriptors/` sub-directory in the root of the module sources.
 Should the descriptors not be found in the standard `descriptors/` sub-directory, then the first match found during a file search is used.
 These sources are checked out by this script and are automatically removed at the end of a successful operation.
+If the modules already exist in the check out directory, then they are neither cloned nor are they removed at the end of a successful operation.
 
 The non-UI modules are built using `sed` replacements to avoid the expensive process of building the descriptors through the normal mechanisms, such as `mvn package`
 The UI modules are built using `yarn run build-mod-descriptor`.

--- a/README.md
+++ b/README.md
@@ -322,8 +322,10 @@ bash BUILD_LOCATION_LIMIT=100 BUILD_LOCATION_DELAY="0.3s" script/build_location.
 ### Build Module Descriptors
 
 The **Build Module Descriptors** script provides a way to build multiple **Deployment Descriptors** and **Module Descriptors** files.
-The purpose of this script is to act as a temporary helper tool for constructing the descriptors using only an `install.json` file for use in a legacy [OKAPI](https://github.com/folio-org/okapi/) environment.
-This approach has limitations, but these limitations are of little concern given that [OKAPI](https://github.com/folio-org/okapi/) is now considered a legacy application.
+The purpose of this script is to act as a helper tool for constructing the descriptors using only an `install.json` file, such as for use in a legacy [OKAPI](https://github.com/folio-org/okapi/) environment.
+This approach is similar to the `populate_release.sh`, but instead of using pre-created descriptors from a running registry, it constructs the descriptors directly from the source code.
+The `populate_release.sh` script requires a running repository with the packages in them.
+This script can operate even if the descriptors are not available in a running repository.
 
 The descriptors are first searched for at the `descriptors/` sub-directory in the root of the module sources.
 Should the descriptors not be found in the standard `descriptors/` sub-directory, then the first match found during a file search is used.
@@ -417,17 +419,18 @@ This overridden name is not used for the purposes of the `exact` and `pcre` matc
 | `BUILD_MOD_DESCRIPTORS_DEBUG`              | Enable debug verbosity, any non-empty string enables this.
 | `BUILD_MOD_DESCRIPTORS_DEFAULT_BRANCH`     | Specify the default branch to checkout (usually either `main` or `master`).
 | `BUILD_MOD_DESCRIPTORS_DEFAULT_REPOSITORY` | The default repository URL prefix (usually a GitHub URL).
+| `BUILD_MOD_DESCRIPTORS_DEPLOY_PATH`        | The output directory to save all built deployment descriptors.
 | `BUILD_MOD_DESCRIPTORS_FILES`              | The input files to process (usually only `install.json`).
 | `BUILD_MOD_DESCRIPTORS_FLOWER`             | The Flower release name, such as `quesnelia` or `snapshot`.
 | `BUILD_MOD_DESCRIPTORS_INPUT_PATH`         | The directory containing the templates and settings.
-| `BUILD_MOD_DESCRIPTORS_OUTPUT_PATH`        | The output directory to save all build descriptors.
+| `BUILD_MOD_DESCRIPTORS_MODULE_PATH`        | The output directory to save all built module descriptors.
 | `BUILD_MOD_DESCRIPTORS_RESTRICT_TO`        | A list of module prefixes from the `install.json` files to limit the processing to.
 
 View the documentation within the `build_module_descriptors.sh` script for further details on how to operate this script.
 
 Example usage:
 ```shell
-BUILD_MOD_DESCRIPTORS_FLOWER="quesnelia" BUILD_MOD_DESCRIPTORS_CHECKOUT_PATH="../checkout/" BUILD_MOD_DESCRIPTORS_INPUT_PATH="../input/" BUILD_MOD_DESCRIPTORS_OUTPUT_PATH="../output/" bash script/build_module_descriptors.sh
+BUILD_MOD_DESCRIPTORS_FLOWER="quesnelia" BUILD_MOD_DESCRIPTORS_CHECKOUT_PATH="../checkout/" BUILD_MOD_DESCRIPTORS_INPUT_PATH="../input/" BUILD_MOD_DESCRIPTORS_DEPLOY_PATH="../deploy/" BUILD_MOD_DESCRIPTORS_MODULE_PATH="../release/" bash script/build_module_descriptors.sh
 ```
 
 

--- a/script/build_module_descriptors.sh
+++ b/script/build_module_descriptors.sh
@@ -1,0 +1,1093 @@
+#!/bin/bash
+#
+# Build module and deployment descriptors, either synthetically or normally.
+#
+# This attempts to directly build the module descriptor using the ModuleDescriptor-template.json, without calling the normal build process.
+# This is done to avoid the resource and time cost of calling something like "mvn clean package -DskipTests".
+#
+# This utilizes the install.json file to construct the Module Descriptor JSON files.
+#
+# This requires the following user-space programs:
+#   - bash
+#   - file
+#   - find
+#   - git
+#   - grep
+#   - jq
+#   - mkdir
+#   - sed
+#   - yarn
+#
+# See the repository `README.md` for the listing of the environment variables and parameters.
+#
+# The BUILD_MOD_DESCRIPTORS_DEBUG may be specifically set to "json" to include printing the json commands.
+# The BUILD_MOD_DESCRIPTORS_DEBUG may be specifically set to "json_only" to only print the json commands, disabling all other debugging.
+# The BUILD_MOD_DESCRIPTORS_DEBUG may be specifically set to "yarn" to include running yarn in verbose mode.
+# The BUILD_MOD_DESCRIPTORS_DEBUG may be specifically set to "yarn_only" to only include running yarn in verbose mode, disabling all other debugging (does not pass -v).
+#
+
+main() {
+  local IFS=$' \t\n' # Protect IFS from security issue before anything is done.
+  local checkout_path="checkout/"
+  local debug=
+  local debug_json=
+  local debug_yarn=
+  local default_branch=
+  local default_repository="https://github.com/folio-org/"
+  local deploy_descriptor="DeploymentDescriptor-template.json"
+  local file=
+  local files="install.json"
+  local flower="snapshot"
+  local input_path="template/descriptor/"
+  local input_path_replace=
+  local input_path_setting=
+  local json=
+  local module_descriptor="ModuleDescriptor-template.json"
+  local null="/dev/null"
+  local output_path="descriptors/"
+  local output_path_deploy=
+  local output_path_flower=
+  local output_path_module=
+  local replace_names=
+  local restrict_to="edge- folio_ mod-"
+  local restrict_to_regex=
+  local setting_json=
+
+  # Custom prefixes for debug and error.
+  local p_d="DEBUG: "
+  local p_e="ERROR: "
+
+  local -A replace_data=
+  local -A replace_keys=
+  local -A replace_size=
+
+  local -i result=0
+  local -i replace_names_length=0
+
+  build_mod_desc_load_environment ${*}
+  build_mod_desc_load_templates
+
+  for file in ${files} ; do
+    build_mod_desc_build
+
+    if [[ ${result} -ne 0 ]] ; then break ; fi
+  done
+
+  if [[ ${result} -eq 0 ]] ; then
+    echo "Done: Module and Deployment Descriptor JSON files are built ."
+    echo
+  fi
+
+  return ${result}
+}
+
+build_mod_desc_build() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  local branch=
+  local destination_deploy=
+  local destination_module=
+  local id=
+  local into_path=
+  local json=
+  local skip_reason=
+  local method=
+  local module=
+  local module_raw=
+  local module_type=
+  local original_path="${PWD}/"
+  local pcre_value=
+  local reduced_json=
+  local repository=
+  local specific_deploy_descriptor=
+  local specific_module_descriptor=
+  local type=
+  local value=
+
+  local -i i=0
+  local -i total=0
+  local -i skip=0
+
+  build_mod_desc_build_reduce
+  build_mod_desc_load_json_total "length" "${file}" "${reduced_json}"
+
+  if [[ ${total} -eq 0 && ${debug} != "" ]] ; then
+    echo "${p_d}No modules found in the input file: ${file} ."
+  else
+    echo "Operating on ${total} items in input file: ${file} ."
+  fi
+
+  echo
+
+  while [[ ${i} -lt ${total} ]] ; do
+    id=
+    method=
+    module=
+    module_raw=
+    repository=
+    specific_deploy_descriptor=${deploy_descriptor}
+    specific_module_descriptor=${module_descriptor}
+    type=
+    version=
+
+    let skip=0
+
+    build_mod_desc_build_get_id
+    build_mod_desc_build_get_module
+    build_mod_desc_build_get_version
+
+    # Alter ID based on possibly modified module name and version (before renaming to preserve the ID).
+    id="${module}-${version}"
+    destination_deploy="${output_path_deploy}${id}.json"
+    destination_module="${output_path_module}${id}.json"
+
+    build_mod_desc_build_get_descriptor
+    build_mod_desc_build_get_rename
+    build_mod_desc_build_get_omit
+    build_mod_desc_build_get_operate
+
+    build_mod_desc_build_skip_descriptor
+    build_mod_desc_build_skip_unknown
+
+    if [[ ${result} -ne 0 ]] ; then return ; fi
+
+    if [[ ${skip} -eq 1 ]] ; then
+      build_mod_desc_print_debug "Skipping id=${id}, module=${module}, module_raw=${module_raw}, version=${version} at index ${i} of ${total}, reason: ${skip_reason}"
+
+      let i++;
+      continue
+    fi
+
+    branch="${default_branch}"
+    into_path="${checkout_path}${module}/"
+
+    if [[ ${debug} == "" ]] ; then
+      echo "Processing id=${id} at index ${i} of ${total}."
+      echo
+    else
+      build_mod_desc_print_debug "Processing id=${id}, module=${module}, module_raw=${module_raw}, version=${version} at index ${i} of ${total}"
+    fi
+
+    build_mod_desc_build_clone
+    build_mod_desc_build_operate
+    build_mod_desc_build_cleanup
+
+    let i++
+  done
+}
+
+build_mod_desc_build_clone() {
+
+  if [[ ${result} -ne 0 || -d ${into_path} ]] ; then return ; fi
+
+  if [[ ${branch} == "" ]] ; then
+    git clone ${debug} --depth 1 --no-tags "${repository}" "${into_path}"
+  else
+    git clone ${debug} -b "${branch}" --depth 1 --no-tags "${repository}" "${into_path}"
+  fi
+
+  build_mod_desc_handle_result "Failed to clone repository ${module} using branch '${branch}' into path '${into_path}' for repository: ${repository}"
+
+  # Add a new line to make the logs easier to read when removing verbosely.
+  if [[ ${result} -eq 0 && ${debug} != "" ]] ; then
+    echo
+  fi
+}
+
+build_mod_desc_build_cleanup() {
+
+  if [[ ${result} -ne 0 || ${into_path} == "" || ${into_path} == "/" || ${into_path} == "." || ${into_path} == "./" ]] ; then return ; fi
+  if [[ ${into_path} == ".." || ${into_path} == "../" || "${PWD}/" != ${original_path} ]] ; then return ; fi
+
+  if [[ -d ${into_path} ]] ; then
+    rm ${debug} -Rf "${into_path}"
+
+    # Ignore remove failures.
+    let result=${?}
+
+    # Add a new line to make the logs easier to read when removing verbosely.
+    if [[ ${debug} != "" ]] ; then
+      echo
+    fi
+
+    if [[ ${result} -ne 0 ]] ; then
+      build_mod_desc_print_debug "Failed to recursively remove directory for ${module} (system code ${result}): ${into_path}"
+
+      let result=0
+    fi
+  fi
+}
+
+build_mod_desc_build_get_descriptor() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  build_mod_desc_build_get_override_for "descriptor" ".discovery_name"
+
+  if [[ ${value} != "" ]] ; then
+    specific_deploy_descriptor=${value}
+  fi
+
+  build_mod_desc_build_get_override_for "descriptor" ".module_name"
+
+  if [[ ${value} != "" ]] ; then
+    specific_module_descriptor=${value}
+  fi
+}
+
+build_mod_desc_build_get_id() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  local key=".[${i}].id"
+
+  build_mod_desc_load_json_for "${key}" "${file}" "${reduced_json}" "-r"
+  id="${value}"
+
+  if [[ ${result} -eq 0 && ${id} == "" ]] ; then
+    echo "${p_e}Empty id for key='${key}' at index ${i} from JSON: ${file} ."
+    echo
+
+    let result=1
+    return
+  fi
+}
+
+build_mod_desc_build_get_operate_for() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  local json=${2}
+  local match=${1}
+  local repo_type=
+
+  build_mod_desc_load_json_for "${match}.repository.branch" "${input_path_setting}" "${json}" "-r" yes
+
+  if [[ ${value} != "null" ]] ; then
+    branch=${value}
+  fi
+
+  build_mod_desc_load_json_for "${match}.method" "${input_path_setting}" "${json}" "-r"
+
+  if [[ ${value} != "" ]] ; then
+    method=${value}
+  fi
+
+  build_mod_desc_load_json_for "${match}.repository.type" "${input_path_setting}" "${json}" "-r"
+
+  if [[ ${value} != "" ]] ; then
+    repo_type=${value}
+  fi
+
+  build_mod_desc_load_json_for "${match}.repository.url" "${input_path_setting}" "${json}" "-r"
+
+  if [[ ${value} == "" ]] ; then
+    repository=${default_repository}${module}
+  else
+    if [[ ${repo_type} == "partial" ]] ; then
+      repository=${value}${module}
+    elif [[ ${repo_type} == "full" || ${repo_type} == "" ]] ; then
+      repository=${value}
+    fi
+  fi
+
+  build_mod_desc_load_json_for "${match}.type" "${input_path_setting}" "${json}" "-r"
+
+  if [[ ${value} != "" ]] ; then
+    type=${value}
+  fi
+}
+
+build_mod_desc_build_get_module() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  if [[ ${id} == "" ]] ; then
+    echo "${p_e}Empty id at index ${i} from JSON: ${file} ."
+    echo
+
+    let result=1
+    return
+  fi
+
+  module=
+  module_type=
+  module_raw=$(echo -n "${id}" | sed -e "s|-SNAPSHOT*||" -e "s|-[^-]*$||")
+
+  build_mod_desc_handle_result "Failed to extract module name from key '${key}' at index ${i} from JSON: ${file}"
+
+  if [[ ${result} -eq 0 ]] ; then
+    if [[ $(grep -sho "^folio_" <<< ${module_raw}) == "" ]] ; then
+      module=${module_raw}
+      module_type="normal"
+    else
+      module=$(sed -e "s|^folio_|ui-|" <<< ${module_raw})
+      module_type="ui"
+    fi
+
+    if [[ ${module_raw} == "" ]] ; then
+      echo "${p_e}Empty module name from key '${id}' at index ${i} from JSON: ${file} ."
+      echo
+
+      let result=1
+    fi
+  fi
+}
+
+build_mod_desc_build_get_omit() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  build_mod_desc_build_get_override_for "omit" ".type"
+
+  if [[ ${value} == "always" ]] ; then
+    skip_reason="omitted by override"
+
+    let skip=1
+  fi
+}
+
+build_mod_desc_build_get_operate() {
+
+  local operate_key=".operate"
+  local pcre_key="${operate_key}.pcre"
+
+  local -i pcre_matched=0
+
+  build_mod_desc_build_get_operate_for "${operate_key}.exact.\"${module_raw}\"" "${setting_json}"
+
+  if [[ ${method} == "" ]] ; then
+    build_mod_desc_build_get_setting_pcre "${pcre_key}" "${setting_json}"
+    build_mod_desc_build_get_setting_pcre_match_module "${pcre_key}" "${setting_json}"
+  fi
+}
+
+build_mod_desc_build_get_override_for() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  local override_key=".override.${1}"
+  local override_value=
+  local pcre_key="${override_key}.pcre"
+  local subkey=${2}
+
+  local -i pcre_matched=0
+
+  build_mod_desc_load_json_for "${override_key}.exact.\"${module_raw}\"${subkey}" "${input_path_setting}" "${setting_json}" "-r"
+  override_value=${value}
+
+  if [[ ${override_value} == "" ]] ; then
+    build_mod_desc_build_get_setting_pcre "${pcre_key}" "${setting_json}"
+    build_mod_desc_build_get_setting_pcre_match_value "${pcre_key}" "${subkey}" "${setting_json}"
+
+    if [[ ${pcre_matched} -eq 1 ]] ; then
+      override_value=${value}
+    fi
+  fi
+
+  value=${override_value}
+}
+
+build_mod_desc_build_get_rename() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  build_mod_desc_build_get_override_for "rename" ".to"
+
+  if [[ ${value} != "" ]] ; then
+    module=${value}
+  fi
+}
+
+build_mod_desc_build_get_setting_pcre() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  local json=${3}
+  local key=${1}
+  local pcre_json=
+
+  local -i i=0
+  local -i total=0
+
+  pcre_value=
+
+  let pcre_matched=0
+
+  build_mod_desc_load_json_for "${key} | keys" "${input_path_setting}" "${setting_json}"
+  pcre_json=${value}
+
+  build_mod_desc_load_json_total "length" "${input_path_setting}" "${pcre_json}"
+
+  while [[ ${i} -lt ${total} ]] ; do
+    build_mod_desc_load_json_for ".[${i}]" "${input_path_setting}" "${pcre_json}" "-r"
+    pcre_value=${value}
+
+    if [[ ${pcre_value} != "" && $(echo -n "${module_raw}" | grep -shoP "${pcre_value}") != "" ]] ; then
+      let pcre_matched=1
+    fi
+
+    if [[ ${result} -ne 0 || ${pcre_matched} -eq 1 ]] ; then return ; fi
+
+    let i++
+  done
+}
+
+build_mod_desc_build_get_setting_pcre_match_module() {
+
+  if [[ ${result} -ne 0 || ${pcre_matched} -ne 1 ]] ; then return ; fi
+
+  local json=${2}
+  local key=${1}
+
+  build_mod_desc_build_get_operate_for "${key}.\"${pcre_value}\"" "${json}"
+}
+
+build_mod_desc_build_get_setting_pcre_match_value() {
+
+  if [[ ${result} -ne 0 || ${pcre_matched} -ne 1 ]] ; then return ; fi
+
+  local json=${3}
+  local key=${1}
+  local subkey=${2}
+
+  build_mod_desc_load_json_for "${key}.\"${pcre_value}\"${subkey}" "${input_path_setting}" "${json}" "-r"
+}
+
+build_mod_desc_build_get_version() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  version=$(echo -n "${id}" | sed -e "s|^${module_raw}-||g")
+
+  build_mod_desc_handle_result "Failed to extract version from key '${key}' at index ${i} from JSON: ${file}"
+
+  if [[ ${result} -eq 0 && ${version} == "" ]] ; then
+    echo "${p_e}Empty version from key '${key}' at index ${i} from JSON: ${file} ."
+    echo
+
+    let result=1
+  fi
+}
+
+build_mod_desc_build_operate() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  local source_module="${into_path}descriptors/${specific_module_descriptor}"
+  local source_deploy="${into_path}descriptors/${specific_deploy_descriptor}"
+
+  if [[ ${method} == "jq" ]] ; then
+    build_mod_desc_build_operate_jq_find module "${source_module}" "${specific_module_descriptor}" "${destination_module}"
+    build_mod_desc_build_operate_jq_find deploy "${source_deploy}" "${specific_deploy_descriptor}" "${destination_deploy}"
+
+    build_mod_desc_build_operate_jq_build module "${source_module}" "${destination_module}"
+    build_mod_desc_build_operate_jq_build deploy "${source_deploy}" "${destination_deploy}" yes
+  elif [[ ${method} == "yarn" ]] ; then
+    build_mod_desc_build_operate_yarn_change_into
+    build_mod_desc_build_operate_yarn_build
+    build_mod_desc_build_operate_yarn_copy
+
+    # Always change back to the original path regardless of the error state.
+    cd ${original_path}
+  fi
+}
+
+build_mod_desc_build_operate_jq_build() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  local destination=${3}
+  local key=
+  local kind=${1}
+  local optional=${4}
+  local source=${2}
+  local with=
+
+  local -i i=0
+  local -i replace_total=${replace_size[${type}]}
+
+  # Skip already created descriptors.
+  if [[ -f ${destination} ]] ; then return ; fi
+
+  if [[ ${optional} != "" && ! -e ${source} ]] ; then
+    build_mod_desc_print_debug "Skipping missing ${kind} descriptor due to being optional: ${source}"
+    return
+  fi
+
+  build_mod_desc_load_json "${kind} descriptor template" "${source}"
+
+  while [[ ${i} -lt ${replace_total} ]] ; do
+    build_mod_desc_load_json_for ".[${i}]" "Template Key for '${type}' at ${i}" "${replace_keys[${type}]}" "-r"
+    key=${value}
+
+    build_mod_desc_load_json_for ".\"${key}\"" "Template Value for '${type}' at ${i}" "${replace_data[${type}]}" "-r"
+    with=${value}
+
+    build_mod_desc_build_operate_jq_build_sed
+
+    if [[ ${result} -ne 0 ]] ; then return ; fi
+
+    let i++
+  done
+
+  build_mod_desc_build_operate_jq_build_write
+}
+
+build_mod_desc_build_operate_jq_build_sed() {
+
+  if [[ ${result} -ne 0 || ${key} == "" ]] ; then return ; fi
+
+  local data=
+  local value=
+
+  if [[ ${with} == "description" ]] ; then
+    # There is no value in the install.json for description, so always evaluate to an empty string.
+    value=
+  elif [[ ${with} == "id" ]] ; then
+    value=${id}
+  elif [[ ${with} == "module" ]] ; then
+    value=${module}
+  elif [[ ${with} == "version" ]] ; then
+    value=${version}
+  else
+    build_mod_desc_print_debug "Unknown type identifier while processing ${module} with key='${key}': ${with}"
+
+    return
+  fi
+
+  data=$(sed -e "s|${key}|${value}|g" <<< ${json})
+
+  build_mod_desc_handle_result "Failed to replace '${key}' with ${with} '${value}' using sed for: ${module}"
+
+  if [[ ${result} -eq 0 ]] ; then
+    json=${data}
+  fi
+}
+
+build_mod_desc_build_operate_jq_build_write() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  # Prevent jq from printing JSON if ${null} exists when not debugging.
+  if [[ ${debug_json} != "" || ! -e ${null} ]] ; then
+    jq -M . <<< ${json} > ${destination}
+  else
+    jq -M . <<< ${json} > ${destination} 2> ${null}
+  fi
+
+  build_mod_desc_handle_result "Failed to write ${module} ${kind} descriptor to: ${destination}"
+}
+
+build_mod_desc_build_operate_jq_find() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  local destination=${4}
+  local expect_at=${2}
+  local find_file=${3}
+  local found_at=
+  local kind=${1}
+
+  if [[ -e ${expect_at} && ! -f ${expect_at} ]] ; then
+    build_mod_desc_print_debug "The ${kind} descriptor for ${module} is not a valid JSON file: ${expect_at}"
+
+    return
+  fi
+
+  build_mod_desc_build_operate_jq_find_search
+  build_mod_desc_build_operate_jq_find_assign
+}
+
+build_mod_desc_build_operate_jq_find_assign() {
+
+  if [[ ${result} -ne 0 || ${found_at} == "" || ! -f ${found_at} ]] ; then return ; fi
+
+  if [[ ${kind} == "module" ]] ; then
+    source_module=${found_at}
+  else
+    source_deploy=${found_at}
+  fi
+}
+
+build_mod_desc_build_operate_jq_find_search() {
+
+  if [[ ${result} -ne 0 || -f ${expect_at} ]] ; then return ; fi
+
+  found_at=$(find ${into_path} -name ${find_file} -print -quit)
+
+  build_mod_desc_handle_result "Failed to find the ${kind} descriptor file for ${module}: ${find_file}"
+}
+
+build_mod_desc_build_operate_yarn_build() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  yarn ${debug_yarn} run build-mod-descriptor
+
+  build_mod_desc_handle_result "Failed to execute yarn run build-mod-descriptor for: ${id}"
+}
+
+build_mod_desc_build_operate_yarn_change_into() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  cd ${into_path}
+
+  build_mod_desc_handle_result "Failed to change to directory for ${module}: ${into_path}"
+}
+
+build_mod_desc_build_operate_yarn_copy() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  local destination="${original_path}${output_path_module}${id}.json"
+  local source="module-descriptor.json"
+
+  cp ${debug} "${source}" "${destination}"
+
+  build_mod_desc_handle_result "Failed to copy '${source}' to: ${destination}"
+
+  # Add a new line to make the logs easier to read when removing verbosely.
+  if [[ ${result} -eq 0 && ${debug} != "" ]] ; then
+    echo
+  fi
+}
+
+build_mod_desc_build_reduce() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  local jq_restrict="sort | .[] | select(.id | test(\"${restrict_to_regex}\"))"
+
+  # Prevent jq from printing JSON if ${null} exists when not debugging.
+  if [[ ${debug_json} != "" || ! -e ${null} ]] ; then
+    if [[ ${restrict_to_regex} == "" ]] ; then
+      reduced_json=$(jq -r -M . ${file})
+    else
+      reduced_json=$(jq -r -M "${jq_restrict}" ${file} | jq -s -M '.')
+    fi
+  else
+    if [[ ${restrict_to_regex} == "" ]] ; then
+      reduced_json=$(jq -r -M . ${file} 2> ${null})
+    else
+      reduced_json=$(jq -r -M "${jq_restrict}" ${file} 2> ${null} | jq -s -M '.' 2> ${null})
+    fi
+  fi
+
+  build_mod_desc_handle_result "Failed to reduce using '${restrict_to}' for JSON: ${file}"
+}
+
+build_mod_desc_build_skip_descriptor() {
+
+  if [[ ${result} -ne 0 || ${skip} -ne 0 ]] ; then return ; fi
+
+  local deploy_value=
+  local module_value=
+
+  build_mod_desc_build_get_override_for "descriptor" ".use_discovery"
+  deploy_value=${value}
+
+  build_mod_desc_build_get_override_for "descriptor" ".use_module"
+  module_value=${value}
+
+  if [[ -f ${destination_deploy} || ${deploy_value} == "skip" ]] ; then
+    if [[ -f ${destination_module} || ${module_value} == "skip" ]] ; then
+      skip_reason="descriptors found or skipped"
+
+      let skip=1
+    fi
+  fi
+}
+
+build_mod_desc_build_skip_unknown() {
+
+  if [[ ${result} -ne 0 || ${skip} -ne 0 ]] ; then return ; fi
+
+  if [[ ${type} != "" && ${type} != "none" && ${replace_data[${type}]} == "" ]] ; then
+    skip_reason="unknown type of '${type}'"
+
+    let skip=1
+  elif [[ ${method} != "jq" && ${method} != "yarn" ]] ; then
+    skip_reason="unknown method of '${method}'"
+
+    let skip=1
+  fi
+}
+
+build_mod_desc_handle_result() {
+  let result=${?}
+
+  if [[ ${result} -ne 0 ]] ; then
+    echo "${p_e}${1} (system code ${result})."
+    echo
+  fi
+}
+
+build_mod_desc_load_environment() {
+  local file=
+  local i=
+  local simplified=
+
+  if [[ ${BUILD_MOD_DESCRIPTORS_DEBUG} != "" ]] ; then
+    debug="-v"
+    debug_json=
+    debug_yarn="-s"
+
+    if [[ $(echo ${BUILD_MOD_DESCRIPTORS_DEBUG} | grep -sho "^\s*json\s*$") != "" ]] ; then
+      debug_json="y"
+    elif [[ $(echo ${BUILD_MOD_DESCRIPTORS_DEBUG} | grep -sho "^\s*yarn\s*$") != "" ]] ; then
+      debug_yarn="--verbose"
+    elif [[ $(echo ${BUILD_MOD_DESCRIPTORS_DEBUG} | grep -sho "^\s*json_only\s*$") != "" ]] ; then
+      debug=
+      debug_json="y"
+    elif [[ $(echo ${BUILD_MOD_DESCRIPTORS_DEBUG} | grep -sho "^\s*yarn_only\s*$") != "" ]] ; then
+      debug=
+      debug_yarn="--verbose"
+    elif [[ $(echo ${BUILD_MOD_DESCRIPTORS_DEBUG} | grep -sho "_only") != "" ]] ; then
+      debug=
+    else
+      if [[ $(echo ${BUILD_MOD_DESCRIPTORS_DEBUG} | grep -sho "\<json\>") != "" ]] ; then
+        debug_json="y"
+      fi
+
+      if [[ $(echo ${BUILD_MOD_DESCRIPTORS_DEBUG} | grep -sho "\<yarn\>") != "" ]] ; then
+        debug_yarn="--verbose"
+      fi
+    fi
+  fi
+
+  # May be empty, so use "-v" test rather than != "".
+  if [[ -v BUILD_MOD_DESCRIPTORS_BRANCH ]] ; then
+    default_branch=${BUILD_MOD_DESCRIPTORS_BRANCH}
+  fi
+
+  if [[ $(echo -n "${default_branch}" | grep -sho "[/\\\"\']") != "" ]] ; then
+    echo "${p_e}The default branch must not contain '/', '\', ''', or '\"' characters: ${default_branch} ."
+
+    let result=1
+    return
+  fi
+
+  if [[ ${BUILD_MOD_DESCRIPTORS_DEFAULT_REPOSITORY} != "" ]] ; then
+    default_repository=$(echo -n ${BUILD_MOD_DESCRIPTORS_DEFAULT_REPOSITORY} | sed -e 's|//*|/|g' -e 's|/*$|/|g')
+  fi
+
+  if [[ $(echo ${BUILD_MOD_DESCRIPTORS_FILES} | sed -e 's|\s||g') != "" ]] ; then
+    files=
+
+    for i in ${BUILD_MOD_DESCRIPTORS_FILES} ; do
+      file=$(echo ${BUILD_MOD_DESCRIPTORS_FILES} | sed -e 's|//*|/|g' -e 's|/*$||')
+
+      build_mod_desc_print_debug "Using File: ${file}"
+
+      files="${files}${file} "
+    done
+  fi
+
+  if [[ ${BUILD_MOD_DESCRIPTORS_INPUT_PATH} != "" ]] ; then
+    input_path=$(echo -n ${BUILD_MOD_DESCRIPTORS_INPUT_PATH} | sed -e 's|//*|/|g' -e 's|/*$|/|g')
+  fi
+
+  if [[ $(grep -sho '^[/\]' <<< ${input_path}) == "" && $(grep -shoP '^\w+\:[/\\]+' <<< ${input_path}) != "" ]] ; then
+    input_path="${original_path}${input_path}"
+  fi
+
+  input_path_replace="${input_path}replace.json"
+  input_path_setting="${input_path}setting.json"
+
+  # May be empty, so use "-v" test rather than != "".
+  if [[ -v BUILD_MOD_DESCRIPTORS_RESTRICT_TO ]] ; then
+    restrict_to=${BUILD_MOD_DESCRIPTORS_RESTRICT_TO}
+  fi
+
+  restrict_to_regex=
+
+  if [[ ${restrict_to} != "" ]] ; then
+    for i in ${restrict_to} ; do
+      simplified=$(echo ${i} | grep -shoP "[\w-]*")
+
+      if [[ ${simplified} != "" ]] ; then
+        if [[ ${restrict_to_regex} == "" ]] ; then
+          restrict_to_regex="^${simplified}"
+        else
+          restrict_to_regex="${restrict_to_regex}|^${simplified}"
+        fi
+      fi
+    done
+  fi
+
+  if [[ ${BUILD_MOD_DESCRIPTORS_FLOWER} != "" ]] ; then
+    flower=$(echo ${BUILD_MOD_DESCRIPTORS_FLOWER} | sed -e 's|/||g')
+  fi
+
+  if [[ $(echo -n ${flower} | grep -sho "[/\\\"\']") != "" ]] ; then
+    echo "${p_e}The flower must not contain '/', '\', ''', or '\"' characters: ${flower} ."
+
+    let result=1
+    return
+  fi
+
+  # May be empty, so use "-v" test rather than != "".
+  if [[ -v BUILD_MOD_DESCRIPTORS_OUTPUT_PATH ]] ; then
+    if [[ ${BUILD_MOD_DESCRIPTORS_OUTPUT_PATH} == "" ]] ; then
+      output_path=
+    else
+      output_path=$(echo -n ${BUILD_MOD_DESCRIPTORS_OUTPUT_PATH} | sed -e 's|//*|/|g' -e 's|/*$|/|g')
+    fi
+  fi
+
+  if [[ $(grep -sho '^[/\]' <<< ${output_path}) == "" && $(grep -shoP '^\w+\:[/\\]+' <<< ${output_path}) != "" ]] ; then
+    output_path="${original_path}${output_path}"
+  fi
+
+  if [[ ${flower} != "" ]] ; then
+    output_path_flower="${output_path}${flower}/"
+  else
+    output_path_flower="${output_path}"
+  fi
+
+  output_path_deploy="${output_path_flower}deploy/"
+  output_path_module="${output_path_flower}module/"
+
+  build_mod_desc_verify_directory "output deploy path" "${output_path_deploy}" create
+  build_mod_desc_verify_directory "output module path" "${output_path_module}" create
+
+  # May be empty, so use "-v" test rather than != "".
+  if [[ -v BUILD_MOD_DESCRIPTORS_CHECKOUT_PATH ]] ; then
+    if [[ ${BUILD_MOD_DESCRIPTORS_CHECKOUT_PATH} == "" ]] ; then
+      checkout_path=
+    else
+      checkout_path=$(echo -n ${BUILD_MOD_DESCRIPTORS_CHECKOUT_PATH} | sed -e 's|//*|/|g' -e 's|/*$|/|g')
+    fi
+  fi
+
+  build_mod_desc_verify_directory "check out path" "${checkout_path}" create
+}
+
+build_mod_desc_load_json() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  local file=${2}
+  local name=${1}
+
+  # Prevent jq from printing JSON if ${null} exists when not debugging.
+  if [[ ${debug_json} != "" || ! -e ${null} ]] ; then
+    json=$(jq -M . ${file})
+  else
+    json=$(jq -M . ${file} 2> ${null})
+  fi
+
+  build_mod_desc_handle_result "Failed to load ${name} from ${file}"
+}
+
+build_mod_desc_load_json_for() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  local args=${4}
+  local jq_select_by=${1}
+  local json=${3}
+  local keep_null=${5}
+  local name=${2}
+
+  # Prevent jq from printing JSON if ${null} exists when not debugging.
+  if [[ ${debug_json} != "" || ! -e ${null} ]] ; then
+    value=$(jq ${args} -M "${jq_select_by}" <<< ${json})
+  else
+    value=$(jq ${args} -M "${jq_select_by}" <<< ${json} 2> ${null})
+  fi
+
+  build_mod_desc_handle_result "Failed to load JSON with select='${jq_select_by}', args='${args}', and keep_null='${keep_null}' for ${name}"
+
+  # JQ returns the literal "null" for not found, replace with empty string.
+  if [[ ${keep_null} == "" && ${value} == "null" ]] ; then
+    value=
+  fi
+}
+
+build_mod_desc_load_json_total() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  local data=
+  local jq_total=${1}
+  local json=${3}
+  local name=${2}
+  local raw=${4}
+
+  # Prevent jq from printing JSON if ${null} exists when not debugging.
+  if [[ ${debug_json} != "" || ! -e ${null} ]] ; then
+    data=$(jq -r -M "${jq_total}" <<< ${json})
+  else
+    data=$(jq -r -M "${jq_total}" <<< ${json} 2> ${null})
+  fi
+
+  build_mod_desc_handle_result "Failed to load JSON length with select='${jq_total}' for ${name}"
+
+  if [[ ${result} -eq 0 && ${data} != "" && ${data} != "null" ]] ; then
+    let total=${data}
+  else
+    let total=0
+  fi
+}
+
+build_mod_desc_load_json_verify_files() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  local file=
+
+  for file in ${files} ; do
+    build_mod_desc_verify_json "input file" "${file}"
+
+    if [[ ${result} -ne 0 ]] ; then return ; fi
+  done
+
+  build_mod_desc_verify_json "replace file" "${input_path_replace}"
+  build_mod_desc_verify_json "setting file" "${input_path_setting}"
+}
+
+build_mod_desc_load_templates() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  local jq_merge='reduce .[] as $f ({}; . * $f)'
+  local names=
+  local type=
+  local value=
+
+  local -i i=0
+  local -i total=0
+
+  build_mod_desc_load_json_verify_files
+
+  build_mod_desc_load_json "replace file" "${input_path_replace}"
+  build_mod_desc_load_json_for "keys" "${input_path_replace}" "${json}"
+  names=${value}
+
+  build_mod_desc_load_json_total "length" "${input_path_replace}" "${names}"
+
+  while [[ ${i} -lt ${total} ]] ; do
+    build_mod_desc_load_json_for ".[${i}]" "${input_path_replace}" "${names}" "-r"
+    type=${value}
+
+    build_mod_desc_load_json_for ".\"${type}\"" "${input_path_replace}" "${json}" "-r"
+    replace_data["${type}"]=${value}
+
+    if [[ ${result} -ne 0 ]] ; then return ; fi
+
+    let i++
+  done
+
+  build_mod_desc_load_json_for "keys" "${input_path_replace}" "${json}"
+  replace_names=${value}
+
+  build_mod_desc_load_json_total "length" "${input_path_replace}" "${json}"
+  replace_names_length=${total}
+
+  let i=0
+  while [[ ${i} -lt ${replace_names_length} ]] ; do
+    build_mod_desc_load_json_for ".[${i}]" "${input_path_replace}" "${replace_names}"
+    type=${value}
+
+    # Ignore the reserved keys.
+    if [[ ${type} == "all" || ${type} == "none" ]] ; then
+      let i++
+      continue;
+    fi
+
+    build_mod_desc_load_json_for "${jq_merge}" "${input_path_replace}" "${json}"
+    replace_data[${type}]=${value}
+
+    build_mod_desc_load_json_for "keys" "${input_path_replace}" "${replace_data[${type}]}"
+    replace_keys[${type}]=${value}
+
+    build_mod_desc_load_json_total "length" "${input_path_replace}" "${replace_keys[${type}]}"
+    replace_size[${type}]=${total}
+
+    if [[ ${result} -ne 0 ]] ; then return ; fi
+
+    let i++
+  done
+
+  build_mod_desc_load_json_for "${jq_merge}" "${input_path_replace}" "${json}"
+  replace_data[all]=${value}
+
+  build_mod_desc_load_json_for "keys" "${input_path_replace}" "${replace_data[all]}"
+  replace_keys[all]=${value}
+
+  build_mod_desc_load_json_total "length" "${input_path_replace}" "${replace_keys[all]}"
+  replace_size[all]=${total}
+
+  let total=0
+  replace_data[none]=
+  replace_keys[none]=
+  replace_size[none]=${total}
+
+  build_mod_desc_load_json "setting file" "${input_path_setting}"
+  setting_json=${json}
+}
+
+build_mod_desc_print_debug() {
+
+  if [[ ${debug} == "" ]] ; then return ; fi
+
+  echo "${p_d}${1} ."
+  echo
+}
+
+build_mod_desc_verify_directory() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  local name=${1}
+  local path=${2}
+  local option=${3}
+
+  # Optionally attempt create the directory if it does not exist.
+  if [[ ${option} == "create" ]] ; then
+    if [[ ! -e ${path} ]] ; then
+      mkdir -p ${debug} "${path}"
+
+      build_mod_desc_handle_result "Failed to create the ${name} directory: ${path}"
+
+      if [[ ${result} -ne 0 ]] ; then return ; fi
+    fi
+  fi
+
+  if [[ ! -d ${path} ]] ; then
+    echo "${p_e}The ${name} is not a valid directory: ${path} ."
+
+    let result=1
+  fi
+}
+
+build_mod_desc_verify_json() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  local name=${1}
+  local file=${2}
+
+  if [[ ${file} == "" || ! -f ${file} ]] ; then
+    let result=1
+  else
+    if [[ ${debug_json} != "" || ! -e ${null} ]] ; then
+      jq < ${file}
+    else
+      jq < ${file} >> ${null} 2>&1
+    fi
+
+    let result=${?}
+  fi
+
+  if [[ ${result} -ne 0 ]] ; then
+    echo "${p_e}The ${name} '${file}' does not exist or is not a valid JSON file."
+    echo
+  fi
+}
+
+main ${*}

--- a/script/build_module_descriptors.sh
+++ b/script/build_module_descriptors.sh
@@ -739,24 +739,24 @@ build_mod_desc_load_environment() {
     debug_json=
     debug_yarn="-s"
 
-    if [[ $(echo ${BUILD_MOD_DESCRIPTORS_DEBUG} | grep -sho "^\s*json\s*$") != "" ]] ; then
+    if [[ $(grep -sho "^\s*json\s*$" <<< ${BUILD_MOD_DESCRIPTORS_DEBUG}) != "" ]] ; then
       debug_json="y"
-    elif [[ $(echo ${BUILD_MOD_DESCRIPTORS_DEBUG} | grep -sho "^\s*yarn\s*$") != "" ]] ; then
+    elif [[ $(grep -sho "^\s*yarn\s*$" <<< ${BUILD_MOD_DESCRIPTORS_DEBUG}) != "" ]] ; then
       debug_yarn="--verbose"
-    elif [[ $(echo ${BUILD_MOD_DESCRIPTORS_DEBUG} | grep -sho "^\s*json_only\s*$") != "" ]] ; then
+    elif [[ $(grep -sho "^\s*json_only\s*$" <<< ${BUILD_MOD_DESCRIPTORS_DEBUG}) != "" ]] ; then
       debug=
       debug_json="y"
-    elif [[ $(echo ${BUILD_MOD_DESCRIPTORS_DEBUG} | grep -sho "^\s*yarn_only\s*$") != "" ]] ; then
+    elif [[ $(grep -sho "^\s*yarn_only\s*$" <<< ${BUILD_MOD_DESCRIPTORS_DEBUG}) != "" ]] ; then
       debug=
       debug_yarn="--verbose"
-    elif [[ $(echo ${BUILD_MOD_DESCRIPTORS_DEBUG} | grep -sho "_only") != "" ]] ; then
+    elif [[ $(grep -sho "_only" <<< ${BUILD_MOD_DESCRIPTORS_DEBUG}) != "" ]] ; then
       debug=
     else
-      if [[ $(echo ${BUILD_MOD_DESCRIPTORS_DEBUG} | grep -sho "\<json\>") != "" ]] ; then
+      if [[ $(grep -sho "\<json\>" <<< ${BUILD_MOD_DESCRIPTORS_DEBUG}) != "" ]] ; then
         debug_json="y"
       fi
 
-      if [[ $(echo ${BUILD_MOD_DESCRIPTORS_DEBUG} | grep -sho "\<yarn\>") != "" ]] ; then
+      if [[ $(grep -sho "\<yarn\>" <<< ${BUILD_MOD_DESCRIPTORS_DEBUG}) != "" ]] ; then
         debug_yarn="--verbose"
       fi
     fi
@@ -767,7 +767,7 @@ build_mod_desc_load_environment() {
     default_branch=${BUILD_MOD_DESCRIPTORS_BRANCH}
   fi
 
-  if [[ $(echo -n "${default_branch}" | grep -sho "[/\\\"\']") != "" ]] ; then
+  if [[ $(grep -sho "[/\\\"\']" <<< ${default_branch}) != "" ]] ; then
     echo "${p_e}The default branch must not contain '/', '\', ''', or '\"' characters: ${default_branch} ."
 
     let result=1
@@ -775,14 +775,14 @@ build_mod_desc_load_environment() {
   fi
 
   if [[ ${BUILD_MOD_DESCRIPTORS_DEFAULT_REPOSITORY} != "" ]] ; then
-    default_repository=$(echo -n ${BUILD_MOD_DESCRIPTORS_DEFAULT_REPOSITORY} | sed -e 's|//*|/|g' -e 's|/*$|/|g')
+    default_repository=$(sed -e 's|//*|/|g' -e 's|/*$|/|g' <<< ${BUILD_MOD_DESCRIPTORS_DEFAULT_REPOSITORY})
   fi
 
-  if [[ $(echo ${BUILD_MOD_DESCRIPTORS_FILES} | sed -e 's|\s||g') != "" ]] ; then
+  if [[ $(sed -e 's|\s||g' <<< ${BUILD_MOD_DESCRIPTORS_FILES}) != "" ]] ; then
     files=
 
     for i in ${BUILD_MOD_DESCRIPTORS_FILES} ; do
-      file=$(echo ${BUILD_MOD_DESCRIPTORS_FILES} | sed -e 's|//*|/|g' -e 's|/*$||')
+      file=$(sed -e 's|//*|/|g' -e 's|/*$||' <<< ${BUILD_MOD_DESCRIPTORS_FILES})
 
       build_mod_desc_print_debug "Using File: ${file}"
 
@@ -791,7 +791,7 @@ build_mod_desc_load_environment() {
   fi
 
   if [[ ${BUILD_MOD_DESCRIPTORS_INPUT_PATH} != "" ]] ; then
-    input_path=$(echo -n ${BUILD_MOD_DESCRIPTORS_INPUT_PATH} | sed -e 's|//*|/|g' -e 's|/*$|/|g')
+    input_path=$(sed -e 's|//*|/|g' -e 's|/*$|/|g' <<< ${BUILD_MOD_DESCRIPTORS_INPUT_PATH})
   fi
 
   if [[ $(grep -sho '^[/\]' <<< ${input_path}) == "" && $(grep -shoP '^\w+\:[/\\]+' <<< ${input_path}) != "" ]] ; then
@@ -810,7 +810,7 @@ build_mod_desc_load_environment() {
 
   if [[ ${restrict_to} != "" ]] ; then
     for i in ${restrict_to} ; do
-      simplified=$(echo ${i} | grep -shoP "[\w-]*")
+      simplified=$(grep -shoP "[\w-]*" <<< ${i})
 
       if [[ ${simplified} != "" ]] ; then
         if [[ ${restrict_to_regex} == "" ]] ; then
@@ -860,7 +860,7 @@ build_mod_desc_load_environment() {
     if [[ ${BUILD_MOD_DESCRIPTORS_CHECKOUT_PATH} == "" ]] ; then
       checkout_path=
     else
-      checkout_path=$(echo -n ${BUILD_MOD_DESCRIPTORS_CHECKOUT_PATH} | sed -e 's|//*|/|g' -e 's|/*$|/|g')
+      checkout_path=$(sed -e 's|//*|/|g' -e 's|/*$|/|g' <<< ${BUILD_MOD_DESCRIPTORS_CHECKOUT_PATH})
     fi
   fi
 

--- a/script/build_module_descriptors.sh
+++ b/script/build_module_descriptors.sh
@@ -310,12 +310,12 @@ build_mod_desc_build_get_operate_for() {
   build_mod_desc_load_json_for ".repository.url" "${input_path_setting}" "${json}" "-r"
 
   if [[ ${value} == "" ]] ; then
-    repository=${default_repository}${module}
+    repository=$(sed -e 's|/*$|/|g' <<< ${default_repository}${module})
   else
     if [[ ${repo_type} == "partial" ]] ; then
-      repository=${value}${module}
+      repository=$(sed -e 's|/*$|/|g' <<< ${value}${module})
     elif [[ ${repo_type} == "full" || ${repo_type} == "" ]] ; then
-      repository=${value}
+      repository=$(sed -e 's|/*$|/|g' <<< ${value})
     fi
   fi
 

--- a/script/build_module_descriptors.sh
+++ b/script/build_module_descriptors.sh
@@ -105,6 +105,7 @@ build_mod_desc_build() {
   local type=
   local value=
 
+  local -i exists=0
   local -i i=0
   local -i total=0
   local -i skip=0
@@ -131,6 +132,7 @@ build_mod_desc_build() {
     type=
     version=
 
+    let exists=0
     let skip=0
 
     build_mod_desc_build_get_id
@@ -179,7 +181,14 @@ build_mod_desc_build() {
 
 build_mod_desc_build_clone() {
 
-  if [[ ${result} -ne 0 || -d ${into_path} ]] ; then return ; fi
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  if [[ -d ${into_path} ]] ; then
+    build_mod_desc_print_debug "Skipping clone of module ${module}, already exists at path: ${into_path}"
+
+    let exists=1
+    return
+  fi
 
   if [[ ${branch} == "" ]] ; then
     git clone ${debug} --depth 1 --no-tags "${repository}" "${into_path}"
@@ -198,24 +207,21 @@ build_mod_desc_build_clone() {
 build_mod_desc_build_cleanup() {
 
   if [[ ${result} -ne 0 || ${into_path} == "" || ${into_path} == "/" || ${into_path} == "." || ${into_path} == "./" ]] ; then return ; fi
-  if [[ ${into_path} == ".." || ${into_path} == "../" || "${PWD}/" != ${original_path} ]] ; then return ; fi
+  if [[ ${into_path} == ".." || ${into_path} == "../" || "${PWD}/" != ${original_path} || ! -d ${into_path} || ${exists} -eq 1 ]] ; then return ; fi
 
-  if [[ -d ${into_path} ]] ; then
-    rm ${debug} -Rf "${into_path}"
+  rm ${debug} -Rf "${into_path}"
 
-    # Ignore remove failures.
-    let result=${?}
+  let result=${?}
 
-    # Add a new line to make the logs easier to read when removing verbosely.
-    if [[ ${debug} != "" ]] ; then
-      echo
-    fi
+  # Add a new line to make the logs easier to read when removing verbosely.
+  if [[ ${debug} != "" ]] ; then
+    echo
+  fi
 
-    if [[ ${result} -ne 0 ]] ; then
-      build_mod_desc_print_debug "Failed to recursively remove directory for ${module} (system code ${result}): ${into_path}"
+  if [[ ${result} -ne 0 ]] ; then
+    build_mod_desc_print_debug "Failed to recursively remove directory for ${module} (system code ${result}): ${into_path}"
 
-      let result=0
-    fi
+    let result=0
   fi
 }
 

--- a/script/build_module_descriptors.sh
+++ b/script/build_module_descriptors.sh
@@ -2,10 +2,10 @@
 #
 # Build module and deployment descriptors, either synthetically or normally.
 #
-# This attempts to directly build the module descriptor using the ModuleDescriptor-template.json, without calling the normal build process.
+# This attempts to directly build the descriptor using the template JSON files, without calling the normal build process.
 # This is done to avoid the resource and time cost of calling something like "mvn clean package -DskipTests".
 #
-# This utilizes the install.json file to construct the Module Descriptor JSON files.
+# This utilizes the install.json file, by default, to construct the descriptor JSON files.
 #
 # This requires the following user-space programs:
 #   - bash
@@ -44,10 +44,8 @@ main() {
   local json=
   local module_descriptor="ModuleDescriptor-template.json"
   local null="/dev/null"
-  local output_path="descriptors/"
-  local output_path_deploy=
-  local output_path_flower=
-  local output_path_module=
+  local output_path_deploy="deploy/"
+  local output_path_module="release/"
   local replace_names=
   local restrict_to="edge- folio_ mod-"
   local restrict_to_regex=
@@ -648,7 +646,7 @@ build_mod_desc_build_operate_yarn_copy() {
 
   if [[ ${result} -ne 0 ]] ; then return ; fi
 
-  local destination="${original_path}${output_path_module}${id}.json"
+  local destination="${output_path_module}${id}.json"
   local source="module-descriptor.json"
 
   cp ${debug} "${source}" "${destination}"
@@ -824,38 +822,35 @@ build_mod_desc_load_environment() {
     done
   fi
 
-  if [[ ${BUILD_MOD_DESCRIPTORS_FLOWER} != "" ]] ; then
-    flower=$(echo ${BUILD_MOD_DESCRIPTORS_FLOWER} | sed -e 's|/||g')
+  if [[ ${BUILD_MOD_DESCRIPTORS_DEPLOY_PATH} != "" ]] ; then
+    output_path_deploy=$(sed -e 's|//*|/|g' -e 's|/*$|/|g' <<< ${BUILD_MOD_DESCRIPTORS_DEPLOY_PATH})
+
+    if [[ $(grep -sho '^[/\]' <<< ${output_path_deploy}) == "" && $(grep -shoP '^\w+\:[/\\]+' <<< ${output_path_deploy}) != "" ]] ; then
+      output_path_deploy="${original_path}${output_path_deploy}"
+    fi
   fi
 
-  if [[ $(echo -n ${flower} | grep -sho "[/\\\"\']") != "" ]] ; then
+  if [[ ${BUILD_MOD_DESCRIPTORS_MODULE_PATH} != "" ]] ; then
+    output_path_module=$(sed -e 's|//*|/|g' -e 's|/*$|/|g' <<< ${BUILD_MOD_DESCRIPTORS_MODULE_PATH})
+
+    if [[ $(grep -sho '^[/\]' <<< ${output_path_module}) == "" && $(grep -shoP '^\w+\:[/\\]+' <<< ${output_path_module}) != "" ]] ; then
+      output_path_module="${original_path}${output_path_module}"
+    fi
+  fi
+
+  if [[ ${BUILD_MOD_DESCRIPTORS_FLOWER} != "" ]] ; then
+    flower=$(sed -e 's|/||g' <<< ${BUILD_MOD_DESCRIPTORS_FLOWER})
+  fi
+
+  if [[ $(grep -sho "[/\\\"\']" <<< ${flower}) != "" ]] ; then
     echo "${p_e}The flower must not contain '/', '\', ''', or '\"' characters: ${flower} ."
 
     let result=1
     return
   fi
 
-  # May be empty, so use "-v" test rather than != "".
-  if [[ -v BUILD_MOD_DESCRIPTORS_OUTPUT_PATH ]] ; then
-    if [[ ${BUILD_MOD_DESCRIPTORS_OUTPUT_PATH} == "" ]] ; then
-      output_path=
-    else
-      output_path=$(echo -n ${BUILD_MOD_DESCRIPTORS_OUTPUT_PATH} | sed -e 's|//*|/|g' -e 's|/*$|/|g')
-    fi
-  fi
-
-  if [[ $(grep -sho '^[/\]' <<< ${output_path}) == "" && $(grep -shoP '^\w+\:[/\\]+' <<< ${output_path}) != "" ]] ; then
-    output_path="${original_path}${output_path}"
-  fi
-
-  if [[ ${flower} != "" ]] ; then
-    output_path_flower="${output_path}${flower}/"
-  else
-    output_path_flower="${output_path}"
-  fi
-
-  output_path_deploy="${output_path_flower}deploy/"
-  output_path_module="${output_path_flower}module/"
+  output_path_deploy="${output_path_deploy}${flower}/"
+  output_path_module="${output_path_module}${flower}/"
 
   build_mod_desc_verify_directory "output deploy path" "${output_path_deploy}" create
   build_mod_desc_verify_directory "output module path" "${output_path_module}" create

--- a/script/build_module_descriptors.sh
+++ b/script/build_module_descriptors.sh
@@ -55,6 +55,14 @@ main() {
   local p_d="DEBUG: "
   local p_e="ERROR: "
 
+  local -A operate_exact=
+  local -A operate_pcre=
+  local -A override_descriptor_exact=
+  local -A override_descriptor_pcre=
+  local -A override_omit_exact=
+  local -A override_omit_pcre=
+  local -A override_rename_exact=
+  local -A override_rename_pcre=
   local -A replace_data=
   local -A replace_keys=
   local -A replace_size=
@@ -147,12 +155,11 @@ build_mod_desc_build() {
     build_mod_desc_build_get_omit
     build_mod_desc_build_get_operate
 
-    build_mod_desc_build_skip_descriptor
     build_mod_desc_build_skip_unknown
 
     if [[ ${result} -ne 0 ]] ; then return ; fi
 
-    if [[ ${skip} -eq 1 ]] ; then
+    if [[ ${skip} -ne 0 ]] ; then
       build_mod_desc_print_debug "Skipping id=${id}, module=${module}, module_raw=${module_raw}, version=${version} at index ${i} of ${total}, reason: ${skip_reason}"
 
       let i++;
@@ -225,18 +232,35 @@ build_mod_desc_build_cleanup() {
 
 build_mod_desc_build_get_descriptor() {
 
-  if [[ ${result} -ne 0 ]] ; then return ; fi
+  if [[ ${result} -ne 0 || ${skip} -ne 0 ]] ; then return ; fi
 
-  build_mod_desc_build_get_override_for "descriptor" ".discovery_name"
+  local deploy_value=
+  local module_value=
+
+  build_mod_desc_build_get_override_for "descriptor" "discovery_name"
 
   if [[ ${value} != "" ]] ; then
     specific_deploy_descriptor=${value}
   fi
 
-  build_mod_desc_build_get_override_for "descriptor" ".module_name"
+  build_mod_desc_build_get_override_for "descriptor" "module_name"
 
   if [[ ${value} != "" ]] ; then
     specific_module_descriptor=${value}
+  fi
+
+  build_mod_desc_build_get_override_for "descriptor" "use_discovery"
+  deploy_value=${value}
+
+  build_mod_desc_build_get_override_for "descriptor" "use_module"
+  module_value=${value}
+
+  if [[ -f ${destination_deploy} || ${deploy_value} == "skip" ]] ; then
+    if [[ -f ${destination_module} || ${module_value} == "skip" ]] ; then
+      skip_reason="descriptors found or skipped"
+
+      let skip=1
+    fi
   fi
 }
 
@@ -262,29 +286,28 @@ build_mod_desc_build_get_operate_for() {
 
   if [[ ${result} -ne 0 ]] ; then return ; fi
 
-  local json=${2}
-  local match=${1}
+  local json=${1}
   local repo_type=
 
-  build_mod_desc_load_json_for "${match}.repository.branch" "${input_path_setting}" "${json}" "-r" yes
+  build_mod_desc_load_json_for ".repository.branch" "${input_path_setting}" "${json}" "-r" yes
 
   if [[ ${value} != "null" ]] ; then
     branch=${value}
   fi
 
-  build_mod_desc_load_json_for "${match}.method" "${input_path_setting}" "${json}" "-r"
+  build_mod_desc_load_json_for ".method" "${input_path_setting}" "${json}" "-r"
 
   if [[ ${value} != "" ]] ; then
     method=${value}
   fi
 
-  build_mod_desc_load_json_for "${match}.repository.type" "${input_path_setting}" "${json}" "-r"
+  build_mod_desc_load_json_for ".repository.type" "${input_path_setting}" "${json}" "-r"
 
   if [[ ${value} != "" ]] ; then
     repo_type=${value}
   fi
 
-  build_mod_desc_load_json_for "${match}.repository.url" "${input_path_setting}" "${json}" "-r"
+  build_mod_desc_load_json_for ".repository.url" "${input_path_setting}" "${json}" "-r"
 
   if [[ ${value} == "" ]] ; then
     repository=${default_repository}${module}
@@ -296,7 +319,7 @@ build_mod_desc_build_get_operate_for() {
     fi
   fi
 
-  build_mod_desc_load_json_for "${match}.type" "${input_path_setting}" "${json}" "-r"
+  build_mod_desc_load_json_for ".type" "${input_path_setting}" "${json}" "-r"
 
   if [[ ${value} != "" ]] ; then
     type=${value}
@@ -341,9 +364,9 @@ build_mod_desc_build_get_module() {
 
 build_mod_desc_build_get_omit() {
 
-  if [[ ${result} -ne 0 ]] ; then return ; fi
+  if [[ ${result} -ne 0 || ${skip} -ne 0 ]] ; then return ; fi
 
-  build_mod_desc_build_get_override_for "omit" ".type"
+  build_mod_desc_build_get_override_for "omit" "type"
 
   if [[ ${value} == "always" ]] ; then
     skip_reason="omitted by override"
@@ -354,16 +377,22 @@ build_mod_desc_build_get_omit() {
 
 build_mod_desc_build_get_operate() {
 
-  local operate_key=".operate"
-  local pcre_key="${operate_key}.pcre"
+  if [[ ${result} -ne 0 || ${skip} -ne 0 ]] ; then return ; fi
 
-  local -i pcre_matched=0
+  local pcre_key=
 
-  build_mod_desc_build_get_operate_for "${operate_key}.exact.\"${module_raw}\"" "${setting_json}"
+  if [[ ${operate_exact[${module_raw}]} != "" ]] ; then
+    build_mod_desc_build_get_operate_for "${operate_exact[${module_raw}]}"
+  fi
 
   if [[ ${method} == "" ]] ; then
-    build_mod_desc_build_get_setting_pcre "${pcre_key}" "${setting_json}"
-    build_mod_desc_build_get_setting_pcre_match_module "${pcre_key}" "${setting_json}"
+    for pcre_key in ${!operate_pcre[@]} ; do
+      if [[ ${operate_pcre[${pcre_key}]} != "" && $(grep -shoP "${pcre_key}" <<< "${module_raw}") != "" ]] ; then
+        build_mod_desc_build_get_operate_for "${operate_pcre[${pcre_key}]}"
+
+        if [[ ${result} -ne 0 ]] ; then return ; fi
+      fi
+    done
   fi
 }
 
@@ -371,21 +400,56 @@ build_mod_desc_build_get_override_for() {
 
   if [[ ${result} -ne 0 ]] ; then return ; fi
 
-  local override_key=".override.${1}"
+  local key=${1}
+  local override_key=".override.${key}"
   local override_value=
-  local pcre_key="${override_key}.pcre"
+  local override_json=
+  local pcre_key=
   local subkey=${2}
 
   local -i pcre_matched=0
 
-  build_mod_desc_load_json_for "${override_key}.exact.\"${module_raw}\"${subkey}" "${input_path_setting}" "${setting_json}" "-r"
-  override_value=${value}
+  if [[ ${key} == "descriptor" ]] ; then
+    override_json=${override_descriptor_exact[${module_raw}]}
+  elif [[ ${key} == "omit" ]] ; then
+    override_json=${override_omit_exact[${module_raw}]}
+  elif [[ ${key} == "rename" ]] ; then
+    override_json=${override_rename_exact[${module_raw}]}
+  fi
+
+  if [[ ${override_json} != "" ]] ; then
+    build_mod_desc_load_json_for ".\"${subkey}\"" "${input_path_setting}" "${override_json}" "-r"
+    override_value=${value}
+  fi
 
   if [[ ${override_value} == "" ]] ; then
-    build_mod_desc_build_get_setting_pcre "${pcre_key}" "${setting_json}"
-    build_mod_desc_build_get_setting_pcre_match_value "${pcre_key}" "${subkey}" "${setting_json}"
+    override_json=
 
-    if [[ ${pcre_matched} -eq 1 ]] ; then
+    if [[ ${key} == "descriptor" ]] ; then
+      for pcre_key in ${!override_descriptor_pcre[@]} ; do
+        if [[ ${override_descriptor_pcre[${pcre_key}]} != "" && $(grep -shoP "${pcre_key}" <<< "${module_raw}") != "" ]] ; then
+          override_json=${override_descriptor_pcre[${pcre_key}]}
+          break
+        fi
+      done
+    elif [[ ${key} == "omit" ]] ; then
+      for pcre_key in ${!override_omit_pcre[@]} ; do
+        if [[ ${override_omit_pcre[${pcre_key}]} != "" && $(grep -shoP "${pcre_key}" <<< "${module_raw}") != "" ]] ; then
+          override_json=${override_omit_pcre[${pcre_key}]}
+          break
+        fi
+      done
+    elif [[ ${key} == "rename" ]] ; then
+      for pcre_key in ${!override_rename_pcre[@]} ; do
+        if [[ ${override_rename_pcre[${pcre_key}]} != "" && $(grep -shoP "${pcre_key}" <<< "${module_raw}") != "" ]] ; then
+          override_json=${override_rename_pcre[${pcre_key}]}
+          break
+        fi
+      done
+    fi
+
+    if [[ ${override_json} != "" ]] ; then
+      build_mod_desc_load_json_for ".\"${subkey}\"" "${input_path_setting}" "${override_json}" "-r"
       override_value=${value}
     fi
   fi
@@ -395,68 +459,13 @@ build_mod_desc_build_get_override_for() {
 
 build_mod_desc_build_get_rename() {
 
-  if [[ ${result} -ne 0 ]] ; then return ; fi
+  if [[ ${result} -ne 0 || ${skip} -ne 0 ]] ; then return ; fi
 
-  build_mod_desc_build_get_override_for "rename" ".to"
+  build_mod_desc_build_get_override_for "rename" "to"
 
   if [[ ${value} != "" ]] ; then
     module=${value}
   fi
-}
-
-build_mod_desc_build_get_setting_pcre() {
-
-  if [[ ${result} -ne 0 ]] ; then return ; fi
-
-  local json=${3}
-  local key=${1}
-  local pcre_json=
-
-  local -i i=0
-  local -i total=0
-
-  pcre_value=
-
-  let pcre_matched=0
-
-  build_mod_desc_load_json_for "${key} | keys" "${input_path_setting}" "${setting_json}"
-  pcre_json=${value}
-
-  build_mod_desc_load_json_total "length" "${input_path_setting}" "${pcre_json}"
-
-  while [[ ${i} -lt ${total} ]] ; do
-    build_mod_desc_load_json_for ".[${i}]" "${input_path_setting}" "${pcre_json}" "-r"
-    pcre_value=${value}
-
-    if [[ ${pcre_value} != "" && $(echo -n "${module_raw}" | grep -shoP "${pcre_value}") != "" ]] ; then
-      let pcre_matched=1
-    fi
-
-    if [[ ${result} -ne 0 || ${pcre_matched} -eq 1 ]] ; then return ; fi
-
-    let i++
-  done
-}
-
-build_mod_desc_build_get_setting_pcre_match_module() {
-
-  if [[ ${result} -ne 0 || ${pcre_matched} -ne 1 ]] ; then return ; fi
-
-  local json=${2}
-  local key=${1}
-
-  build_mod_desc_build_get_operate_for "${key}.\"${pcre_value}\"" "${json}"
-}
-
-build_mod_desc_build_get_setting_pcre_match_value() {
-
-  if [[ ${result} -ne 0 || ${pcre_matched} -ne 1 ]] ; then return ; fi
-
-  local json=${3}
-  local key=${1}
-  local subkey=${2}
-
-  build_mod_desc_load_json_for "${key}.\"${pcre_value}\"${subkey}" "${input_path_setting}" "${json}" "-r"
 }
 
 build_mod_desc_build_get_version() {
@@ -681,28 +690,6 @@ build_mod_desc_build_reduce() {
   fi
 
   build_mod_desc_handle_result "Failed to reduce using '${restrict_to}' for JSON: ${file}"
-}
-
-build_mod_desc_build_skip_descriptor() {
-
-  if [[ ${result} -ne 0 || ${skip} -ne 0 ]] ; then return ; fi
-
-  local deploy_value=
-  local module_value=
-
-  build_mod_desc_build_get_override_for "descriptor" ".use_discovery"
-  deploy_value=${value}
-
-  build_mod_desc_build_get_override_for "descriptor" ".use_module"
-  module_value=${value}
-
-  if [[ -f ${destination_deploy} || ${deploy_value} == "skip" ]] ; then
-    if [[ -f ${destination_module} || ${module_value} == "skip" ]] ; then
-      skip_reason="descriptors found or skipped"
-
-      let skip=1
-    fi
-  fi
 }
 
 build_mod_desc_build_skip_unknown() {
@@ -955,10 +942,17 @@ build_mod_desc_load_templates() {
 
   if [[ ${result} -ne 0 ]] ; then return ; fi
 
+  local jq_descriptor='.override.descriptor'
   local jq_merge='reduce .[] as $f ({}; . * $f)'
+  local jq_omit='.override.omit'
+  local jq_operate='.operate'
+  local jq_rename='.override.rename'
+  local key=
   local names=
   local type=
   local value=
+
+  local -A associative=
 
   local -i i=0
   local -i total=0
@@ -1030,6 +1024,76 @@ build_mod_desc_load_templates() {
 
   build_mod_desc_load_json "setting file" "${input_path_setting}"
   setting_json=${json}
+
+  # Load exact match associative arrays.
+  build_mod_desc_load_templates_associative "${jq_operate}" "exact"
+  for key in ${!associative[@]} ; do if [[ ${associative[${key}]} != "" ]] ; then operate_exact[${key}]=${associative[${key}]} ; fi ; done
+
+  build_mod_desc_load_templates_associative "${jq_descriptor}" "exact"
+  for key in ${!associative[@]} ; do if [[ ${associative[${key}]} != "" ]] ; then override_descriptor_exact[${key}]=${associative[${key}]} ; fi ; done
+
+  build_mod_desc_load_templates_associative "${jq_omit}" "exact"
+  for key in ${!associative[@]} ; do if [[ ${associative[${key}]} != "" ]] ; then override_omit_exact[${key}]=${associative[${key}]} ; fi ; done
+
+  build_mod_desc_load_templates_associative "${jq_rename}" "exact"
+  for key in ${!associative[@]} ; do if [[ ${associative[${key}]} != "" ]] ; then override_rename_exact[${key}]=${associative[${key}]} ; fi ; done
+
+  # Load PCRE match associative arrays.
+  build_mod_desc_load_templates_associative "${jq_operate}" "pcre"
+  for key in ${!associative[@]} ; do if [[ ${associative[${key}]} != "" ]] ; then operate_pcre[${key}]=${associative[${key}]} ; fi ; done
+
+  build_mod_desc_load_templates_associative "${jq_descriptor}" "pcre"
+  for key in ${!associative[@]} ; do if [[ ${associative[${key}]} != "" ]] ; then override_descriptor_pcre[${key}]=${associative[${key}]} ; fi ; done
+
+  build_mod_desc_load_templates_associative "${jq_omit}" "pcre"
+  for key in ${!associative[@]} ; do if [[ ${associative[${key}]} != "" ]] ; then override_omit_pcre[${key}]=${associative[${key}]} ; fi ; done
+
+  build_mod_desc_load_templates_associative "${jq_rename}" "pcre"
+  for key in ${!associative[@]} ; do if [[ ${associative[${key}]} != "" ]] ; then override_rename_pcre[${key}]=${associative[${key}]} ; fi ; done
+}
+
+build_mod_desc_load_templates_associative() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  local jq_value="${1}.${2}"
+  local keys_json=
+
+  build_mod_desc_load_json_for "${jq_value} | keys" "${input_path_setting}" "${setting_json}"
+  keys_json=${value}
+
+  build_mod_desc_load_json_for "${jq_value}" "${input_path_setting}" "${setting_json}"
+  build_mod_desc_load_json_total "${jq_value} | length" "${input_path_setting}" "${setting_json}"
+
+  build_mod_desc_load_templates_associative_for "${keys_json}" "${total}" "${value}"
+}
+
+build_mod_desc_load_templates_associative_for() {
+
+  if [[ ${result} -ne 0 ]] ; then return ; fi
+
+  local array_json=${1}
+  local data_json=${3}
+  local key=
+  local value=
+
+  local -i array_length=${2}
+  local -i i=0
+
+  # Reset the associative array (using unset requires quotes around the key name).
+  for key in "${!associative[@]}"; do unset associative["${key}"] ; done
+
+  while [[ ${i} -lt ${array_length} ]] ; do
+    build_mod_desc_load_json_for ".[${i}]" "${input_path_setting}" "${array_json}" "-r"
+    key=${value}
+
+    if [[ ${result} -ne 0 ]] ; then return ; fi
+
+    build_mod_desc_load_json_for ".\"${key}\"" "${input_path_setting}" "${data_json}"
+    associative[${key}]=${value}
+
+    let i++
+  done
 }
 
 build_mod_desc_print_debug() {

--- a/script/build_module_descriptors.sh
+++ b/script/build_module_descriptors.sh
@@ -345,11 +345,11 @@ build_mod_desc_build_get_module() {
   build_mod_desc_handle_result "Failed to extract module name from key '${key}' at index ${i} from JSON: ${file}"
 
   if [[ ${result} -eq 0 ]] ; then
-    if [[ $(grep -sho "^folio_" <<< ${module_raw}) == "" ]] ; then
+    if [[ $(grep -sho '^folio_' <<< ${module_raw}) == "" ]] ; then
       module=${module_raw}
       module_type="normal"
     else
-      module=$(sed -e "s|^folio_|ui-|" <<< ${module_raw})
+      module=$(sed -e 's|^folio_|ui-|' <<< ${module_raw})
       module_type="ui"
     fi
 
@@ -726,24 +726,24 @@ build_mod_desc_load_environment() {
     debug_json=
     debug_yarn="-s"
 
-    if [[ $(grep -sho "^\s*json\s*$" <<< ${BUILD_MOD_DESCRIPTORS_DEBUG}) != "" ]] ; then
+    if [[ $(grep -sho '^\s*json\s*$' <<< ${BUILD_MOD_DESCRIPTORS_DEBUG}) != "" ]] ; then
       debug_json="y"
-    elif [[ $(grep -sho "^\s*yarn\s*$" <<< ${BUILD_MOD_DESCRIPTORS_DEBUG}) != "" ]] ; then
+    elif [[ $(grep -sho '^\s*yarn\s*$' <<< ${BUILD_MOD_DESCRIPTORS_DEBUG}) != "" ]] ; then
       debug_yarn="--verbose"
-    elif [[ $(grep -sho "^\s*json_only\s*$" <<< ${BUILD_MOD_DESCRIPTORS_DEBUG}) != "" ]] ; then
+    elif [[ $(grep -sho '^\s*json_only\s*$' <<< ${BUILD_MOD_DESCRIPTORS_DEBUG}) != "" ]] ; then
       debug=
       debug_json="y"
-    elif [[ $(grep -sho "^\s*yarn_only\s*$" <<< ${BUILD_MOD_DESCRIPTORS_DEBUG}) != "" ]] ; then
+    elif [[ $(grep -sho '^\s*yarn_only\s*$' <<< ${BUILD_MOD_DESCRIPTORS_DEBUG}) != "" ]] ; then
       debug=
       debug_yarn="--verbose"
-    elif [[ $(grep -sho "_only" <<< ${BUILD_MOD_DESCRIPTORS_DEBUG}) != "" ]] ; then
+    elif [[ $(grep -sho '_only' <<< ${BUILD_MOD_DESCRIPTORS_DEBUG}) != "" ]] ; then
       debug=
     else
-      if [[ $(grep -sho "\<json\>" <<< ${BUILD_MOD_DESCRIPTORS_DEBUG}) != "" ]] ; then
+      if [[ $(grep -sho '\<json\>' <<< ${BUILD_MOD_DESCRIPTORS_DEBUG}) != "" ]] ; then
         debug_json="y"
       fi
 
-      if [[ $(grep -sho "\<yarn\>" <<< ${BUILD_MOD_DESCRIPTORS_DEBUG}) != "" ]] ; then
+      if [[ $(grep -sho '\<yarn\>' <<< ${BUILD_MOD_DESCRIPTORS_DEBUG}) != "" ]] ; then
         debug_yarn="--verbose"
       fi
     fi
@@ -797,7 +797,7 @@ build_mod_desc_load_environment() {
 
   if [[ ${restrict_to} != "" ]] ; then
     for i in ${restrict_to} ; do
-      simplified=$(grep -shoP "[\w-]*" <<< ${i})
+      simplified=$(grep -shoP '[\w-]*' <<< ${i})
 
       if [[ ${simplified} != "" ]] ; then
         if [[ ${restrict_to_regex} == "" ]] ; then

--- a/template/descriptor/replace.json
+++ b/template/descriptor/replace.json
@@ -1,0 +1,20 @@
+{
+  "basic": {
+    "${artifactId}": "module",
+    "${description}": "description",
+    "${name}": "module",
+    "${version}": "version"
+  },
+  "spring": {
+    "@project.artifactId@": "module",
+    "@project.description@": "description",
+    "@project.name@": "module",
+    "@project.version@": "version"
+  },
+  "spring_simple": {
+    "@artifactId@": "module",
+    "@description@": "description",
+    "@name@": "module",
+    "@version@": "version"
+  }
+}

--- a/template/descriptor/setting.json
+++ b/template/descriptor/setting.json
@@ -23,6 +23,7 @@
     },
     "omit": {
       "exact": {
+        "folio_stripes-core": { "type": "always" },
         "mod-z3950": { "type": "always" },
         "okapi": { "type": "always" }
       },

--- a/template/descriptor/setting.json
+++ b/template/descriptor/setting.json
@@ -1,0 +1,42 @@
+{
+  "operate": {
+    "exact": {
+      "mod-camunda": { "method": "jq", "type": "spring" },
+      "mod-graphql": { "method": "jq", "type": "none" },
+      "mod-workflow": { "method": "jq", "type": "spring" }
+    },
+    "pcre": {
+      "edge-*": { "method": "jq", "type": "all" },
+      "folio_*": { "method": "yarn" },
+      "mod-*": { "method": "jq", "type": "all" }
+    }
+  },
+  "override": {
+    "descriptor": {
+      "exact": {
+        "edge-connexion": { "use_discovery": "skip" },
+        "mod-graphql": { "discovery_name": "ExternalDeploymentDescriptor.json", "module_name": "ModuleDescriptor.json" }
+      },
+      "pcre": {
+        "^folio_": { "use_discovery": "skip" }
+      }
+    },
+    "omit": {
+      "exact": {
+        "mod-z3950": { "type": "always" },
+        "okapi": { "type": "always" }
+      },
+      "pcre": {
+      }
+    },
+    "rename": {
+      "exact": {
+        "folio_stripes-authority-components": { "to": "stripes-authority-components" },
+        "folio_stripes-core": { "to": "stripes-core" },
+        "folio_stripes-smart-components": { "to": "stripes-smart-components" }
+      },
+      "pcre": {
+      }
+    }
+  }
+}

--- a/template/descriptor/setting.json
+++ b/template/descriptor/setting.json
@@ -27,13 +27,11 @@
         "okapi": { "type": "always" }
       },
       "pcre": {
+        "^folio_stripes-.+-components": { "type": "always" }
       }
     },
     "rename": {
       "exact": {
-        "folio_stripes-authority-components": { "to": "stripes-authority-components" },
-        "folio_stripes-core": { "to": "stripes-core" },
-        "folio_stripes-smart-components": { "to": "stripes-smart-components" }
       },
       "pcre": {
       }


### PR DESCRIPTION
See `README.md` for some details on how the script works.

Notes about some of the default settings:

The `edge-connexion` lacks a discovery descriptor and must be skipped. The `mod-graphql` uses custom names for the descriptors and those descriptors are pre-created.

The `mod-camunda` and `mod-workflow` are used as a functioning example in the default `maps.json`.

The UI modules don't use deployment descriptors and must be skipped.

The `mod-z3950` is missing or requires special handling and is therefore omitted. The `okapi` module is omitted.

Some of the stripes modules, such as `folio_stripes-authority-components`, `folio_stripes-core`, and `folio_stripes-smart-components` must be renamed. Their projects lack the traditional `ui-` prefix.
It might be better to have these be skipped as they are components or core dependencies.