### PR TITLE
Update code, fixing issues and improving consistency.

### DIFF
--- a/script/build_application_descriptor.sh
+++ b/script/build_application_descriptor.sh
@@ -227,7 +227,7 @@ build_app_desc_get_name() {
 
   if [[ ${result} -ne 0 ]] ; then return ; fi
 
-  name=$(echo -n ${value} | sed -e "s|-SNAPSHOT*||" -e "s|-[^-]*$||")
+  name=$(sed -e 's|-SNAPSHOT*||' -e 's|-[^-]*$||' <<< ${value})
 
   build_app_desc_handle_result "Failed to extract name from key '${key}' at index ${i} from JSON: ${file}"
 
@@ -243,7 +243,7 @@ build_app_desc_get_version() {
 
   if [[ ${result} -ne 0 ]] ; then return ; fi
 
-  version=$(echo -n "${value}" | sed -e "s|^${name}-||g")
+  version=$(sed -e "s|^${name}-||g" <<< ${value})
 
   build_app_desc_handle_result "Failed to extract version from key '${key}' at index ${i} from JSON: ${file}"
 
@@ -272,23 +272,23 @@ build_app_desc_load_environment() {
   if [[ ${BUILD_APP_DESCRIPTOR_DEBUG} != "" ]] ; then
     debug="-v"
 
-    if [[ $(echo ${BUILD_APP_DESCRIPTOR_DEBUG} | grep -sho "^\s*json\s*$") != "" ]] ; then
+    if [[ $(grep -sho "^\s*json\s*$" <<< ${BUILD_APP_DESCRIPTOR_DEBUG}) != "" ]] ; then
       debug_json="y"
-    elif [[ $(echo ${BUILD_APP_DESCRIPTOR_DEBUG} | grep -sho "^\s*json_only\s*$") != "" ]] ; then
+    elif [[ $(grep -sho "^\s*json_only\s*$" <<< ${BUILD_APP_DESCRIPTOR_DEBUG}) != "" ]] ; then
       debug=
       debug_json="y"
-    elif [[ $(echo ${BUILD_APP_DESCRIPTOR_DEBUG} | grep -sho "_only") != "" ]] ; then
+    elif [[ $(grep -sho "_only" <<< ${BUILD_APP_DESCRIPTOR_DEBUG}) != "" ]] ; then
       debug=
-    elif [[ $(echo ${BUILD_APP_DESCRIPTOR_DEBUG} | grep -sho "\<json\>") != "" ]] ; then
+    elif [[ $(grep -sho "\<json\>" <<< ${BUILD_APP_DESCRIPTOR_DEBUG}) != "" ]] ; then
       debug_json="y"
     fi
   fi
 
-  if [[ $(echo ${BUILD_APP_DESCRIPTOR_FILES} | sed -e 's|\s||g') != "" ]] ; then
+  if [[ $(sed -e 's|\s||g' <<< ${BUILD_APP_DESCRIPTOR_FILES}) != "" ]] ; then
     files=
 
     for i in ${BUILD_APP_DESCRIPTOR_FILES} ; do
-      file=$(echo ${BUILD_APP_DESCRIPTOR_FILES} | sed -e 's|//*|/|g' -e 's|/*$||')
+      file=$(sed -e 's|//*|/|g' -e 's|/*$||' <<< ${BUILD_APP_DESCRIPTOR_FILES})
 
       build_app_desc_print_debug "Using File: ${file}"
 
@@ -300,7 +300,7 @@ build_app_desc_load_environment() {
     descriptor_name=${BUILD_APP_DESCRIPTOR_NAME}
   fi
 
-  if [[ $(echo -n ${descriptor_name} | grep -sho "[/\\\"\']") != "" ]] ; then
+  if [[ $(grep -sho "[/\\\"\']" <<< ${descriptor_name}) != "" ]] ; then
     echo "${p_e}The descriptor name must not contain '/', '\', ''', or '\"' characters: ${descriptor_name} ."
 
     let result=1
@@ -311,7 +311,7 @@ build_app_desc_load_environment() {
     descriptor_version=${BUILD_APP_DESCRIPTOR_VERSION}
   fi
 
-  if [[ $(echo -n ${descriptor_version} | grep -sho "[/\\\"\']") != "" ]] ; then
+  if [[ $(grep -sho "[/\\\"\']" <<< ${descriptor_version}) != "" ]] ; then
     echo "${p_e}The descriptor version must not contain '/', '\', ''', or '\"' characters: ${descriptor_version} ."
 
     let result=1
@@ -328,7 +328,7 @@ build_app_desc_load_environment() {
     output_path_name=${BUILD_APP_DESCRIPTOR_OUTPUT_NAME}
   fi
 
-  if [[ $(echo -n ${output_path_name} | grep -sho "[/\\\"\']") != "" ]] ; then
+  if [[ $(grep -sho "[/\\\"\']" <<< ${output_path_name}) != "" ]] ; then
     echo "${p_e}The output path name must not contain '/', '\', ''', or '\"' characters: ${output_path_name} ."
 
     let result=1
@@ -340,13 +340,13 @@ build_app_desc_load_environment() {
     if [[ ${BUILD_APP_DESCRIPTOR_OUTPUT_PATH} == "" ]] ; then
       output_path=
     else
-      output_path=$(echo -n ${BUILD_APP_DESCRIPTOR_OUTPUT_PATH} | sed -e 's|//*|/|g' -e 's|/*$|/|g')
+      output_path=$(sed -e 's|//*|/|g' -e 's|/*$|/|g' <<< ${BUILD_APP_DESCRIPTOR_OUTPUT_PATH})
     fi
   fi
 
   output_path_json="${output_path}${output_path_name}.json"
 
-  if [[ ${BUILD_APP_DESCRIPTOR_RESTRICT_TO} != "" ]] ; then
+  if [[ -v BUILD_APP_DESCRIPTOR_RESTRICT_TO ]] ; then
     restrict_to=${BUILD_APP_DESCRIPTOR_RESTRICT_TO}
   fi
 
@@ -354,7 +354,7 @@ build_app_desc_load_environment() {
     restrict_to_regex=
 
     for i in ${restrict_to} ; do
-      simplified=$(echo ${i} | grep -shoP "[\w-]*")
+      simplified=$(grep -shoP "[\w-]*" <<< ${i})
 
       if [[ ${simplified} != "" ]] ; then
         if [[ ${restrict_to_regex} == "" ]] ; then
@@ -382,13 +382,13 @@ build_app_desc_verify_files() {
   local file=
 
   for file in ${files} ; do
-    build_app_desc_verify_json "input file" ${file}
+    build_app_desc_verify_json "input file" "${file}"
 
     if [[ ${result} -ne 0 ]] ; then return ; fi
   done
 
-  build_app_desc_verify_directory "output path" ${output_path} create
-  build_app_desc_verify_output "output file" ${output_path_json}
+  build_app_desc_verify_directory "output path" "${output_path}" create
+  build_app_desc_verify_output "output file" "${output_path_json}"
 }
 
 build_app_desc_verify_directory() {

--- a/script/build_application_descriptor.sh
+++ b/script/build_application_descriptor.sh
@@ -272,14 +272,14 @@ build_app_desc_load_environment() {
   if [[ ${BUILD_APP_DESCRIPTOR_DEBUG} != "" ]] ; then
     debug="-v"
 
-    if [[ $(grep -sho "^\s*json\s*$" <<< ${BUILD_APP_DESCRIPTOR_DEBUG}) != "" ]] ; then
+    if [[ $(grep -sho '^\s*json\s*$' <<< ${BUILD_APP_DESCRIPTOR_DEBUG}) != "" ]] ; then
       debug_json="y"
-    elif [[ $(grep -sho "^\s*json_only\s*$" <<< ${BUILD_APP_DESCRIPTOR_DEBUG}) != "" ]] ; then
+    elif [[ $(grep -sho '^\s*json_only\s*$' <<< ${BUILD_APP_DESCRIPTOR_DEBUG}) != "" ]] ; then
       debug=
       debug_json="y"
-    elif [[ $(grep -sho "_only" <<< ${BUILD_APP_DESCRIPTOR_DEBUG}) != "" ]] ; then
+    elif [[ $(grep -sho '_only' <<< ${BUILD_APP_DESCRIPTOR_DEBUG}) != "" ]] ; then
       debug=
-    elif [[ $(grep -sho "\<json\>" <<< ${BUILD_APP_DESCRIPTOR_DEBUG}) != "" ]] ; then
+    elif [[ $(grep -sho '\<json\>' <<< ${BUILD_APP_DESCRIPTOR_DEBUG}) != "" ]] ; then
       debug_json="y"
     fi
   fi
@@ -354,7 +354,7 @@ build_app_desc_load_environment() {
     restrict_to_regex=
 
     for i in ${restrict_to} ; do
-      simplified=$(grep -shoP "[\w-]*" <<< ${i})
+      simplified=$(grep -shoP '[\w-]*' <<< ${i})
 
       if [[ ${simplified} != "" ]] ; then
         if [[ ${restrict_to_regex} == "" ]] ; then

--- a/script/build_deployments.sh
+++ b/script/build_deployments.sh
@@ -780,12 +780,12 @@ build_depls_load_environment() {
   if [[ ${BUILD_DEPLOY_DEBUG} != "" ]] ; then
     debug="-v"
 
-    if [[ $(grep -sho "^\s*json_only\s*$" <<< ${BUILD_DEPLOY_DEBUG}) != "" ]] ; then
+    if [[ $(grep -sho '^\s*json_only\s*$' <<< ${BUILD_DEPLOY_DEBUG}) != "" ]] ; then
       debug_json="y"
-    elif [[ $(grep -sho "_only" <<< ${BUILD_DEPLOY_DEBUG}) != "" ]] ; then
+    elif [[ $(grep -sho '_only' <<< ${BUILD_DEPLOY_DEBUG}) != "" ]] ; then
       debug=
     else
-      if [[ $(grep -sho "\<json\>" <<< ${BUILD_DEPLOY_DEBUG}) != "" ]] ; then
+      if [[ $(grep -sho '\<json\>' <<< ${BUILD_DEPLOY_DEBUG}) != "" ]] ; then
         debug_json="y"
       fi
     fi

--- a/script/build_deployments.sh
+++ b/script/build_deployments.sh
@@ -52,7 +52,7 @@ main() {
   local input_path_specific="${input_path}specific/"
   local input_path_vars="${input_path}vars/"
   local input_service_name="service"
-  local jq_instruct
+  local jq_instruct=
   local jq_merge_join=
   local jq_merge_replace=
   local jq_names=
@@ -91,7 +91,7 @@ main() {
   local -i result=0
   local -i passes=4
 
-  build_depls_load_environment
+  build_depls_load_environment ${*}
   build_depls_load_instructions
   build_depls_load_json_sources
   build_depls_load_json_discovery
@@ -123,7 +123,7 @@ build_depls_combine() {
 
   for name in ${names} ; do
 
-    if [[ ${only_these} != "" && $(echo ${only_these} | grep -sho "\<${name}\>") == "" ]] ; then
+    if [[ ${only_these} != "" && $(grep -sho "\<${name}\>" <<< ${only_these}) == "" ]] ; then
       build_depls_print_debug "Skipping combining of ${name} for not being in name restricton list: ${only_these}"
 
       continue
@@ -266,7 +266,7 @@ build_depls_expand() {
 
   for name in ${names} ; do
 
-    if [[ ${only_these} != "" && $(echo ${only_these} | grep -sho "\<${name}\>") == "" ]] ; then
+    if [[ ${only_these} != "" && $(grep -sho "\<${name}\>" <<< ${only_these}) == "" ]] ; then
       build_depls_print_debug "Skipping expansion of ${name} for not being in name restricton list: ${only_these}"
 
       continue
@@ -443,10 +443,10 @@ build_depls_expand_file_load_template_maps_pcre() {
   local pcre_query=
   local pcre_value_deploy=
   local pcre_value_service=
-  local pcre_total=
 
   local -i i=0
   local -i matched=0
+  local -i pcre_total=0
 
   build_depls_expand_file_load_template_maps_pcre_load_map
   build_depls_expand_file_load_template_maps_pcre_load_total
@@ -530,7 +530,7 @@ build_depls_expand_file_load_template_maps_pcre_match_query() {
 
   if [[ ${result} -ne 0 ]] ; then return ; fi
 
-  if [[ $(echo -n "${name}" | grep -shoP "${pcre_query}") != "" ]] ; then
+  if [[ $(grep -shoP "${pcre_query}" <<< ${name}) != "" ]] ; then
     let matched=1
 
     alt_deploy_name="${pcre_value_deploy}"
@@ -674,7 +674,7 @@ build_depls_expand_replace_individual_match() {
 
   local match=${1}
 
-  matches=$(echo "${data}" | grep -shoP "{${match}:[\w-]+}" | sed -e "s|{${match}:| |g" -e "s|}| |g")
+  matches=$(grep -shoP "{${match}:[\w-]+}" <<< ${data} | sed -e "s|{${match}:| |g" -e 's|}| |g')
 
   build_depls_handle_result "Failed extract named replacement matches for field=${field} for ${output}"
 }
@@ -703,7 +703,7 @@ build_depls_expand_replace_individual_replace() {
       return
     fi
 
-    data=$(echo "${data}" | sed -e "s|{${id}:${match}}|${with}|g")
+    data=$(sed -e "s|{${id}:${match}}|${with}|g" <<< ${data})
 
     build_depls_handle_result "Failed regex replace '{${id}:${match}}' using sed for field='${field}' for ${output}"
 
@@ -776,22 +776,23 @@ build_depls_handle_result() {
 }
 
 build_depls_load_environment() {
+
   if [[ ${BUILD_DEPLOY_DEBUG} != "" ]] ; then
     debug="-v"
 
-    if [[ $(echo ${BUILD_DEPLOY_DEBUG} | grep -sho "^\s*json_only\s*$") != "" ]] ; then
+    if [[ $(grep -sho "^\s*json_only\s*$" <<< ${BUILD_DEPLOY_DEBUG}) != "" ]] ; then
       debug_json="y"
-    elif [[ $(echo ${BUILD_DEPLOY_DEBUG} | grep -sho "_only") != "" ]] ; then
+    elif [[ $(grep -sho "_only" <<< ${BUILD_DEPLOY_DEBUG}) != "" ]] ; then
       debug=
     else
-      if [[ $(echo ${BUILD_DEPLOY_DEBUG} | grep -sho "\<json\>") != "" ]] ; then
+      if [[ $(grep -sho "\<json\>" <<< ${BUILD_DEPLOY_DEBUG}) != "" ]] ; then
         debug_json="y"
       fi
     fi
   fi
 
   if [[ ${BUILD_DEPLOY_INPUT_PATH} != "" ]] ; then
-    input_path=$(echo -n ${BUILD_DEPLOY_INPUT_PATH} | sed -e 's|//*|/|g' -e 's|/*$|/|g')
+    input_path=$(sed -e 's|//*|/|g' -e 's|/*$|/|g' <<< ${BUILD_DEPLOY_INPUT_PATH})
     input_path_launches="${input_path}launches/"
     input_path_main="${input_path}main/"
     input_path_specific="${input_path}specific/"
@@ -799,7 +800,7 @@ build_depls_load_environment() {
   fi
 
   if [[ ${BUILD_DEPLOY_OUTPUT_PATH} != "" ]] ; then
-    output_path=$(echo -n ${BUILD_DEPLOY_OUTPUT_PATH} | sed -e 's|//*|/|g' -e 's|/*$|/|g')
+    output_path=$(sed -e 's|//*|/|g' -e 's|/*$|/|g' <<< ${BUILD_DEPLOY_OUTPUT_PATH})
     output_path_yaml="${output_path}yaml/"
     output_path_json="${output_path}json/"
     output_path_json_deploy="${output_path}deploy/"
@@ -820,7 +821,7 @@ build_depls_load_environment() {
     namespace=${BUILD_DEPLOY_NAMESPACE}
   fi
 
-  if [[ $(echo -n ${namespace} | sed -e 's|\-||g' | grep -shPo '\W') != "" ]] ; then
+  if [[ $(sed -e 's|\-||g' <<< ${namespace} | grep -shPo '\W') != "" ]] ; then
     echo "${p_e}The namespace may only contain word characters or the dash '-' character."
 
     let result=1
@@ -838,25 +839,25 @@ build_depls_load_environment() {
     return
   fi
 
-  build_depls_verify_directory "input path" ${input_path} create
-  build_depls_verify_directory "'main' input path" ${input_path_main} create
-  build_depls_verify_directory "'specific' input path" ${input_path_specific} create
-  build_depls_verify_directory "output path" ${output_path} create
-  build_depls_verify_directory "'YAML' output path" ${output_path_yaml} create
-  build_depls_verify_directory "'JSON' output path" ${output_path_json} create
-  build_depls_verify_directory "'deploy JSON' output path" ${output_path_json_deploy} create
-  build_depls_verify_directory "'service JSON' output path" ${output_path_json_service} create
+  build_depls_verify_directory "input path" "${input_path}" create
+  build_depls_verify_directory "'main' input path" "${input_path_main}" create
+  build_depls_verify_directory "'specific' input path" "${input_path_specific}" create
+  build_depls_verify_directory "output path" "${output_path}" create
+  build_depls_verify_directory "'YAML' output path" "${output_path_yaml}" create
+  build_depls_verify_directory "'JSON' output path" "${output_path_json}" create
+  build_depls_verify_directory "'deploy JSON' output path" "${output_path_json_deploy}" create
+  build_depls_verify_directory "'service JSON' output path" "${output_path_json_service}" create
 
-  build_depls_verify_file "'deployment' input file" ${input_path_main}${input_deploy_name}.json
-  build_depls_verify_file "'service' input file" ${input_path_main}${input_service_name}.json
-  build_depls_verify_file "'names' input file" ${input_path_main}${names_base}.json create array
-  build_depls_verify_file "'vars' input file" ${input_path_main}${vars_name}.json create object
-  build_depls_verify_file "'app' output file" ${output_path_yaml}${app}.yaml not ${output_force}
+  build_depls_verify_file "'deployment' input file" "${input_path_main}${input_deploy_name}.json"
+  build_depls_verify_file "'service' input file" "${input_path_main}${input_service_name}.json"
+  build_depls_verify_file "'names' input file" "${input_path_main}${names_base}.json" create array
+  build_depls_verify_file "'vars' input file" "${input_path_main}${vars_name}.json" create object
+  build_depls_verify_file "'app' output file" "${output_path_yaml}${app}.yaml" not "${output_force}"
 
-  build_depls_verify_json "'deployment' input file" ${input_path_main}${input_deploy_name}.json
-  build_depls_verify_json "'service' input file" ${input_path_main}${input_service_name}.json
-  build_depls_verify_json "'names' input file" ${input_path_main}${names_base}.json
-  build_depls_verify_json "'vars' input file" ${input_path_main}${vars_name}.json
+  build_depls_verify_json "'deployment' input file" "${input_path_main}${input_deploy_name}.json"
+  build_depls_verify_json "'service' input file" "${input_path_main}${input_service_name}.json"
+  build_depls_verify_json "'names' input file" "${input_path_main}${names_base}.json"
+  build_depls_verify_json "'vars' input file" "${input_path_main}${vars_name}.json"
 
   if [[ ${BUILD_DEPLOY_DISCOVERY} != "" ]] ; then
     discovery_file=${BUILD_DEPLOY_DISCOVERY}
@@ -870,11 +871,11 @@ build_depls_load_environment() {
     let do_combine=0
     let do_expand=0
 
-    if [[ $(echo ${BUILD_DEPLOY_ACTIONS} | grep -sho '\<combine\>') != "" ]] ; then
+    if [[ $(grep -sho '\<combine\>' <<< ${BUILD_DEPLOY_ACTIONS}) != "" ]] ; then
       let do_combine=1
     fi
 
-    if [[ $(echo ${BUILD_DEPLOY_ACTIONS} | grep -sho '\<expand\>') != "" ]] ; then
+    if [[ $(grep -sho '\<expand\>' <<< ${BUILD_DEPLOY_ACTIONS}) != "" ]] ; then
       let do_expand=1
     fi
 
@@ -887,15 +888,22 @@ build_depls_load_environment() {
   fi
 
   if [[ ${BUILD_DEPLOY_LOCATION_PATH} != "" ]] ; then
-    location_path=$(echo ${BUILD_DEPLOY_LOCATION_PATH} | sed -e 's|//*|/|g' -e 's|/*$|/|')
+    location_path=$(sed -e 's|//*|/|g' -e 's|/*$|/|' <<< ${BUILD_DEPLOY_LOCATION_PATH})
   fi
 
   if [[ ${destination} != "" ]] ; then
-    location_path=$(echo ${location_path} | sed -e 's|/*$|/|')
+    location_path=$(sed -e 's|/*$|/|' <<< ${location_path})
   fi
 
   if [[ ${BUILD_DEPLOY_FLOWER} != "" ]] ; then
-    flower=$(echo ${BUILD_DEPLOY_FLOWER} | sed -e 's|/||g')
+    flower=$(sed -e 's|/||g' <<< ${BUILD_DEPLOY_FLOWER})
+  fi
+
+  if [[ $(grep -sho "[/\\\"\']" <<< ${flower}) != "" ]] ; then
+    echo "${p_e}The flower must not contain '/', '\', ''', or '\"' characters: ${flower} ."
+
+    let result=1
+    return
   fi
 
   location_flower="${location_path}${flower}/"
@@ -914,7 +922,7 @@ build_depls_load_environment() {
     default_repository=${BUILD_DEPLOY_DEFAULT_REPOSITORY}
   fi
 
-  if [[ $(echo ${default_repository} | grep -sho '[/\:&?]') != "" ]] ; then
+  if [[ $(grep -sho '[/\:&?]' <<< ${default_repository}) != "" ]] ; then
     echo "${p_e}The default repository has unsupported characters ('/', '\', ':', '&', and '?'): ${default_repository} ."
 
     let result=1
@@ -1010,20 +1018,20 @@ build_depls_load_json_sources_files() {
 
   for name in ${sources} ; do
 
-    if [[ ${only_these} != "" && $(echo ${only_these} | grep -sho "\<${name}\>") == "" ]] ; then
+    if [[ ${only_these} != "" && $(grep -sho "\<${name}\>" <<< ${only_these}) == "" ]] ; then
       build_depls_print_debug "Skipping loading of ${name} for not being in name restricton list: ${only_these}"
 
       continue
     fi
 
-    build_depls_verify_name ${name} "input file name"
+    build_depls_verify_name "${name}" "input file name"
 
     if [[ ${do_expand} -eq 1 ]] ; then
-      build_depls_verify_file ${name} ${output_path_json_deploy}${name}.json not ${output_force}
-      build_depls_verify_json ${name} ${output_path_json_deploy}${name}.json
+      build_depls_verify_file "${name}" "${output_path_json_deploy}${name}.json" not "${output_force}"
+      build_depls_verify_json "${name}" "${output_path_json_deploy}${name}.json"
 
-      build_depls_verify_file ${name} ${output_path_json_service}${name}.json not ${output_force}
-      build_depls_verify_json ${name} ${output_path_json_service}${name}.json
+      build_depls_verify_file "${name}" "${output_path_json_service}${name}.json" not "${output_force}"
+      build_depls_verify_json "${name}" "${output_path_json_service}${name}.json"
     fi
 
     if [[ ${result} -ne 0 ]] ; then return ; fi
@@ -1275,7 +1283,7 @@ build_depls_verify_name() {
   local name=${1}
   local describe=${2}
 
-  if [[ $(echo -n ${name} | grep -sho "[/\\\"\']") != "" ]] ; then
+  if [[ $(grep -sho "[/\\\"\']" <<< ${name}) != "" ]] ; then
     echo "${p_e}The ${describe} must not contain '/', '\', ''', or '\"' characters: ${name} ."
 
     let result=1

--- a/script/build_latest.sh
+++ b/script/build_latest.sh
@@ -58,14 +58,14 @@ build_latest_load_environment() {
   if [[ ${BUILD_LATEST_DEBUG} != "" ]] ; then
     debug="-v"
 
-    if [[ $(grep -sho "^\s*json\s*$" <<< ${BUILD_LATEST_DEBUG}) != "" ]] ; then
+    if [[ $(grep -sho '^\s*json\s*$' <<< ${BUILD_LATEST_DEBUG}) != "" ]] ; then
       debug_json="y"
-    elif [[ $(grep -sho "^\s*json_only\s*$" <<< ${BUILD_LATEST_DEBUG}) != "" ]] ; then
+    elif [[ $(grep -sho '^\s*json_only\s*$' <<< ${BUILD_LATEST_DEBUG}) != "" ]] ; then
       debug=
       debug_json="y"
-    elif [[ $(grep -sho "_only" <<< ${BUILD_LATEST_DEBUG}) != "" ]] ; then
+    elif [[ $(grep -sho '_only' <<< ${BUILD_LATEST_DEBUG}) != "" ]] ; then
       debug=
-    elif [[ $(grep -sho "\<json\>" <<< ${BUILD_LATEST_DEBUG}) != "" ]] ; then
+    elif [[ $(grep -sho '\<json\>' <<< ${BUILD_LATEST_DEBUG}) != "" ]] ; then
       debug_json="y"
     fi
   fi

--- a/script/build_latest.sh
+++ b/script/build_latest.sh
@@ -58,23 +58,23 @@ build_latest_load_environment() {
   if [[ ${BUILD_LATEST_DEBUG} != "" ]] ; then
     debug="-v"
 
-    if [[ $(echo ${BUILD_LATEST_DEBUG} | grep -sho "^\s*json\s*$") != "" ]] ; then
+    if [[ $(grep -sho "^\s*json\s*$" <<< ${BUILD_LATEST_DEBUG}) != "" ]] ; then
       debug_json="y"
-    elif [[ $(echo ${BUILD_LATEST_DEBUG} | grep -sho "^\s*json_only\s*$") != "" ]] ; then
+    elif [[ $(grep -sho "^\s*json_only\s*$" <<< ${BUILD_LATEST_DEBUG}) != "" ]] ; then
       debug=
       debug_json="y"
-    elif [[ $(echo ${BUILD_LATEST_DEBUG} | grep -sho "_only") != "" ]] ; then
+    elif [[ $(grep -sho "_only" <<< ${BUILD_LATEST_DEBUG}) != "" ]] ; then
       debug=
-    elif [[ $(echo ${BUILD_LATEST_DEBUG} | grep -sho "\<json\>") != "" ]] ; then
+    elif [[ $(grep -sho "\<json\>" <<< ${BUILD_LATEST_DEBUG}) != "" ]] ; then
       debug_json="y"
     fi
   fi
 
-  if [[ $(echo ${BUILD_LATEST_FILES} | sed -e 's|\s||g') != "" ]] ; then
+  if [[ $(sed -e 's|\s||g' <<< ${BUILD_LATEST_FILES}) != "" ]] ; then
     files=
 
     for i in ${BUILD_LATEST_FILES} ; do
-      file=$(echo ${i} | sed -e 's|//*|/|g' -e 's|/*$||')
+      file=$(sed -e 's|//*|/|g' -e 's|/*$||' <<< ${i})
 
       if [[ -f ${file} ]] ; then
         build_latest_print_debug "Using File: ${file}"
@@ -97,7 +97,7 @@ build_latest_load_environment() {
   fi
 
   if [[ ${BUILD_LATEST_PATH} != "" ]] ; then
-    path=$(echo -n ${BUILD_LATEST_PATH} | sed -e 's|//*|/|g' -e 's|/*$|/|g')
+    path=$(sed -e 's|//*|/|g' -e 's|/*$|/|g' <<< ${BUILD_LATEST_PATH})
 
     if [[ ${path} != "" ]] ; then
       if [[ -e ${path} ]] ; then
@@ -134,11 +134,11 @@ build_latest_operate() {
     for i in ${releases} ; do
 
       # Skip any files without the dash in the name used to provide a version.
-      if [[ $(echo ${i} | grep -sho '-') == "" ]] ; then
+      if [[ $(grep -sho '-' <<< ${i}) == "" ]] ; then
         continue
       fi
 
-      release=$(echo -n ${i} | sed -e "s|-SNAPSHOT*||" -e "s|-[^-]*$||")
+      release=$(sed -e 's|-SNAPSHOT*||' -e "s|-[^-]*$||" <<< ${i})
 
       if [[ ! -f ${path}${i} ]] ; then
         if [[ ${skip_not_found} -ne 0 ]] ; then

--- a/script/build_launches.sh
+++ b/script/build_launches.sh
@@ -46,7 +46,7 @@ main() {
 
   local -i result=0
 
-  build_launches_load_environment
+  build_launches_load_environment ${*}
   build_launches_load_instructions
 
   build_launches_build
@@ -154,8 +154,8 @@ build_launches_build_launch_field_exists() {
   if [[ ${result} -ne 0 ]] ; then return ; fi
 
   # The ${value} must be in JQ syntax and must have a "." before the last field being selected.
-  local last=$(echo "${value}" | sed -E 's|^.*\.([^.]+)$|\1|')
-  local first=$(echo "${value}" | sed -e "s|\.${last}||")
+  local last=$(sed -E 's|^.*\.([^.]+)$|\1|' <<< ${value})
+  local first=$(sed -e "s|\.${last}||" <<< ${value})
   local jq_field="${first} | has(\"${last}\")"
 
   # Prevent jq from printing JSON if ${null} exists when not debugging.
@@ -325,10 +325,10 @@ build_launches_build_launch_container_port_process_reduce() {
     if [[ ${data} == "" || ${data} == "null" ]] ; then
       ports_proto[${i}]=
       ports_proto_lower[${i}]=
-    elif [[ $(echo ${data} | grep -shoi "tcp") != "" ]] ; then
+    elif [[ $(grep -shoi "tcp" <<< ${data}) != "" ]] ; then
       ports_proto[${i}]="TCP"
       ports_proto_lower[${i}]="tcp"
-    elif [[ $(echo ${data} | grep -shoi "udp") != "" ]] ; then
+    elif [[ $(grep -shoi "udp" <<< ${data}) != "" ]] ; then
       ports_proto[${i}]="UDP"
       ports_proto_lower[${i}]="udp"
     else
@@ -347,7 +347,7 @@ build_launches_build_path() {
 
   if [[ ${result} -ne 0 || ${launch_json} == "{}" || ${launch_json} == "" ]] ; then return ; fi
 
-  local release=$(echo -n ${input_file} | sed -E 's|.*/+([^/]+)$|\1|' | sed -e "s|-SNAPSHOT*||" -e "s|-[^-]*$||")
+  local release=$(sed -E 's|.*/+([^/]+)$|\1|' <<< ${input_file} | sed -e 's|-SNAPSHOT*||' -e 's|-[^-]*$||')
 
   build_launches_handle_result "Failed to build release path from path: ${input_file}"
 
@@ -375,22 +375,23 @@ build_launches_handle_result() {
 }
 
 build_launches_load_environment() {
+
   if [[ ${BUILD_LAUNCHES_DEBUG} != "" ]] ; then
     debug="-v"
 
-    if [[ $(echo ${BUILD_LAUNCHES_DEBUG} | grep -sho "^\s*json_only\s*$") != "" ]] ; then
+    if [[ $(grep -sho "^\s*json_only\s*$" <<< ${BUILD_LAUNCHES_DEBUG}) != "" ]] ; then
       debug_json="y"
-    elif [[ $(echo ${BUILD_LAUNCHES_DEBUG} | grep -sho "_only") != "" ]] ; then
+    elif [[ $(grep -sho "_only" <<< ${BUILD_LAUNCHES_DEBUG}) != "" ]] ; then
       debug=
     else
-      if [[ $(echo ${BUILD_LAUNCHES_DEBUG} | grep -sho "\<json\>") != "" ]] ; then
+      if [[ $(grep -sho "\<json\>" <<< ${BUILD_LAUNCHES_DEBUG}) != "" ]] ; then
         debug_json="y"
       fi
     fi
   fi
 
   if [[ ${BUILD_LAUNCHES_INPUT_PATH} != "" ]] ; then
-    input_path=$(echo -n ${BUILD_LAUNCHES_INPUT_PATH} | sed -e 's|//*|/|g' -e 's|/*$|/|g')
+    input_path=$(sed -e 's|//*|/|g' -e 's|/*$|/|g' <<< ${BUILD_LAUNCHES_INPUT_PATH})
 
     if [[ -e ${input_path} ]] ; then
       if [[ ! -d ${input_path} ]] ; then
@@ -405,7 +406,7 @@ build_launches_load_environment() {
   input_path_instruct="${input_path}${input_file_instruct}"
 
   if [[ ${BUILD_LAUNCHES_OUTPUT_PATH} != "" ]] ; then
-    output_path=$(echo -n ${BUILD_LAUNCHES_OUTPUT_PATH} | sed -e 's|//*|/|g' -e 's|/*$|/|g')
+    output_path=$(sed -e 's|//*|/|g' -e 's|/*$|/|g' <<< ${BUILD_LAUNCHES_OUTPUT_PATH})
   fi
 
   if [[ -e ${output_path} ]] ; then
@@ -420,7 +421,7 @@ build_launches_load_environment() {
   output_path_launch="${output_path}${output_dir_launch}"
 
   if [[ ${BUILD_LAUNCHES_RELEASE_PATH} != "" ]] ; then
-    release_path=$(echo -n ${BUILD_LAUNCHES_RELEASE_PATH} | sed -e 's|//*|/|g' -e 's|/*$|/|g')
+    release_path=$(sed -e 's|//*|/|g' -e 's|/*$|/|g' <<< ${BUILD_LAUNCHES_RELEASE_PATH})
 
     if [[ -e ${release_path} ]] ; then
       if [[ ! -d ${release_path} ]] ; then

--- a/script/build_launches.sh
+++ b/script/build_launches.sh
@@ -379,12 +379,12 @@ build_launches_load_environment() {
   if [[ ${BUILD_LAUNCHES_DEBUG} != "" ]] ; then
     debug="-v"
 
-    if [[ $(grep -sho "^\s*json_only\s*$" <<< ${BUILD_LAUNCHES_DEBUG}) != "" ]] ; then
+    if [[ $(grep -sho '^\s*json_only\s*$' <<< ${BUILD_LAUNCHES_DEBUG}) != "" ]] ; then
       debug_json="y"
-    elif [[ $(grep -sho "_only" <<< ${BUILD_LAUNCHES_DEBUG}) != "" ]] ; then
+    elif [[ $(grep -sho '_only' <<< ${BUILD_LAUNCHES_DEBUG}) != "" ]] ; then
       debug=
     else
-      if [[ $(grep -sho "\<json\>" <<< ${BUILD_LAUNCHES_DEBUG}) != "" ]] ; then
+      if [[ $(grep -sho '\<json\>' <<< ${BUILD_LAUNCHES_DEBUG}) != "" ]] ; then
         debug_json="y"
       fi
     fi

--- a/script/build_location.sh
+++ b/script/build_location.sh
@@ -98,27 +98,27 @@ build_location_load_environment() {
     debug_curl=
     debug_json=
 
-    if [[ $(grep -sho "^\s*curl\s*$" <<< ${BUILD_LOCATION_DEBUG}) != "" ]] ; then
+    if [[ $(grep -sho '^\s*curl\s*$' <<< ${BUILD_LOCATION_DEBUG}) != "" ]] ; then
       debug_curl="-v"
       debug_curl_silent=
-    elif [[ $(grep -sho "^\s*curl_only\s*$" <<< ${BUILD_LOCATION_DEBUG}) != "" ]] ; then
+    elif [[ $(grep -sho '^\s*curl_only\s*$' <<< ${BUILD_LOCATION_DEBUG}) != "" ]] ; then
       debug=
       debug_curl="-v"
       debug_curl_silent=
-    elif [[ $(grep -sho "^\s*json\s*$" <<< ${BUILD_LOCATION_DEBUG}) != "" ]] ; then
+    elif [[ $(grep -sho '^\s*json\s*$' <<< ${BUILD_LOCATION_DEBUG}) != "" ]] ; then
       debug_json="y"
-    elif [[ $(grep -sho "^\s*json_only\s*$" <<< ${BUILD_LOCATION_DEBUG}) != "" ]] ; then
+    elif [[ $(grep -sho '^\s*json_only\s*$' <<< ${BUILD_LOCATION_DEBUG}) != "" ]] ; then
       debug=
       debug_json="y"
-    elif [[ $(grep -sho "_only" <<< ${BUILD_LOCATION_DEBUG}) != "" ]] ; then
+    elif [[ $(grep -sho '_only' <<< ${BUILD_LOCATION_DEBUG}) != "" ]] ; then
       debug=
     else
-      if [[ $(grep -sho "\<curl\>" <<< ${BUILD_LOCATION_DEBUG}) != "" ]] ; then
+      if [[ $(grep -sho '\<curl\>' <<< ${BUILD_LOCATION_DEBUG}) != "" ]] ; then
         debug_curl="-v"
         debug_curl_silent=
       fi
 
-      if [[ $(grep -sho "\<json\>" <<< ${BUILD_LOCATION_DEBUG}) != "" ]] ; then
+      if [[ $(grep -sho '\<json\>' <<< ${BUILD_LOCATION_DEBUG}) != "" ]] ; then
         debug_json="y"
       fi
     fi

--- a/script/build_location.sh
+++ b/script/build_location.sh
@@ -66,9 +66,9 @@ main() {
   local -i limit=100
   local -i result=0
 
-  build_location_load_environment
+  build_location_load_environment ${*}
 
-  build_location_verify_json "repositories file" ${repositories_json}
+  build_location_verify_json "repositories file" "${repositories_json}"
   build_location_verify_files
 
   build_location_load_repositories
@@ -98,27 +98,27 @@ build_location_load_environment() {
     debug_curl=
     debug_json=
 
-    if [[ $(echo ${BUILD_LOCATION_DEBUG} | grep -sho "^\s*curl\s*$") != "" ]] ; then
+    if [[ $(grep -sho "^\s*curl\s*$" <<< ${BUILD_LOCATION_DEBUG}) != "" ]] ; then
       debug_curl="-v"
       debug_curl_silent=
-    elif [[ $(echo ${BUILD_LOCATION_DEBUG} | grep -sho "^\s*curl_only\s*$") != "" ]] ; then
+    elif [[ $(grep -sho "^\s*curl_only\s*$" <<< ${BUILD_LOCATION_DEBUG}) != "" ]] ; then
       debug=
       debug_curl="-v"
       debug_curl_silent=
-    elif [[ $(echo ${BUILD_LOCATION_DEBUG} | grep -sho "^\s*json\s*$") != "" ]] ; then
+    elif [[ $(grep -sho "^\s*json\s*$" <<< ${BUILD_LOCATION_DEBUG}) != "" ]] ; then
       debug_json="y"
-    elif [[ $(echo ${BUILD_LOCATION_DEBUG} | grep -sho "^\s*json_only\s*$") != "" ]] ; then
+    elif [[ $(grep -sho "^\s*json_only\s*$" <<< ${BUILD_LOCATION_DEBUG}) != "" ]] ; then
       debug=
       debug_json="y"
-    elif [[ $(echo ${BUILD_LOCATION_DEBUG} | grep -sho "_only") != "" ]] ; then
+    elif [[ $(grep -sho "_only" <<< ${BUILD_LOCATION_DEBUG}) != "" ]] ; then
       debug=
     else
-      if [[ $(echo ${BUILD_LOCATION_DEBUG} | grep -sho "\<curl\>") != "" ]] ; then
+      if [[ $(grep -sho "\<curl\>" <<< ${BUILD_LOCATION_DEBUG}) != "" ]] ; then
         debug_curl="-v"
         debug_curl_silent=
       fi
 
-      if [[ $(echo ${BUILD_LOCATION_DEBUG} | grep -sho "\<json\>") != "" ]] ; then
+      if [[ $(grep -sho "\<json\>" <<< ${BUILD_LOCATION_DEBUG}) != "" ]] ; then
         debug_json="y"
       fi
     fi
@@ -136,11 +136,11 @@ build_location_load_environment() {
     return
   fi
 
-  if [[ $(echo ${BUILD_LOCATION_FILES} | sed -e 's|\s||g') != "" ]] ; then
+  if [[ $(sed -e 's|\s||g' <<< ${BUILD_LOCATION_FILES}) != "" ]] ; then
     files=
 
     for i in ${BUILD_LOCATION_FILES} ; do
-      file=$(echo ${i} | sed -e 's|//*|/|g' -e 's|/*$||')
+      file=$(sed -e 's|//*|/|g' -e 's|/*$||' <<< ${i})
 
       if [[ -f ${file} ]] ; then
         build_location_print_debug "Using File: ${file}"
@@ -161,7 +161,7 @@ build_location_load_environment() {
   if [[ ${BUILD_LOCATION_REPOSITORIES_NAME} != "" ]] ; then
     repositories_file=${BUILD_LOCATION_REPOSITORIES_NAME}
 
-    if [[ $(echo -n ${repositories_file} | grep -sho "[/\\\"\']") != "" ]] ; then
+    if [[ $(grep -sho "[/\\\"\']" <<< ${repositories_file}) != "" ]] ; then
       echo "${p_e}The repositories name must not contain '/', '\', ''', or '\"' characters: ${repositories_file} ."
 
       let result=1
@@ -171,7 +171,7 @@ build_location_load_environment() {
   fi
 
   if [[ ${BUILD_LOCATION_REPOSITORIES_PATH} != "" ]] ; then
-    repositories_path=$(echo ${BUILD_LOCATION_REPOSITORIES_PATH} | sed -e 's|//*|/|g' -e 's|/*$|/|')
+    repositories_path=$(sed -e 's|//*|/|g' -e 's|/*$|/|' <<< ${BUILD_LOCATION_REPOSITORIES_PATH})
   fi
 
   repositories_json=${repositories_path}${repositories_file}
@@ -189,15 +189,22 @@ build_location_load_environment() {
   fi
 
   if [[ ${BUILD_LOCATION_DESTINATION} != "" ]] ; then
-    destination=$(echo ${BUILD_LOCATION_DESTINATION} | sed -e 's|//*|/|g' -e 's|/*$|/|')
+    destination=$(sed -e 's|//*|/|g' -e 's|/*$|/|' <<< ${BUILD_LOCATION_DESTINATION})
   fi
 
   if [[ ${destination} != "" ]] ; then
-    destination=$(echo ${destination} | sed -e 's|/*$|/|')
+    destination=$(sed -e 's|/*$|/|' <<< ${destination})
   fi
 
   if [[ ${BUILD_LOCATION_FLOWER} != "" ]] ; then
-    flower=$(echo ${BUILD_LOCATION_FLOWER} | sed -e 's|/||g')
+    flower=$(sed -e 's|/||g' <<< ${BUILD_LOCATION_FLOWER})
+  fi
+
+  if [[ $(grep -sho "[/\\\"\']" <<< ${flower}) != "" ]] ; then
+    echo "${p_e}The flower must not contain '/', '\', ''', or '\"' characters: ${flower} ."
+
+    let result=1
+    return
   fi
 
   destination_flower="${destination}${flower}/"
@@ -211,7 +218,7 @@ build_location_load_environment() {
       return
     fi
   else
-    mkdir ${debug} -p ${destination_flower}
+    mkdir ${debug} -p "${destination_flower}"
 
     build_location_handle_result "Failed to create destination directory path: ${destination_flower}"
   fi
@@ -235,9 +242,9 @@ build_location_load_releases() {
     for i in ${manifest} ; do
 
       # Skip any files without the dash in the name used to provide a version.
-      if [[ $(echo ${i} | grep -sho '-') == "" ]] ; then continue ; fi
+      if [[ $(grep -sho '-' <<< ${i}) == "" ]] ; then continue ; fi
 
-      build_location_parse_release ${i} ${file}
+      build_location_parse_release "${i}" "${file}"
 
       build_location_load_releases_parse_tag
 
@@ -256,7 +263,7 @@ build_location_load_releases_parse_tag() {
     message=" from JSON: ${file}"
   fi
 
-  tags["${release}"]=$(echo -n "${i}" | sed -e "s|^${release}-||")
+  tags["${release}"]=$(sed -e "s|^${release}-||" <<< ${i})
 
   build_location_handle_result "Failed to parse release tag from '${i}'${message}"
 }
@@ -310,9 +317,9 @@ build_location_load_repositories() {
     build_location_load_repositories_extract_domain "auth.registry"
     repositories_auth_registry["${repo}"]="${value}"
 
-    build_location_load_repositories_verify_url "auth.url" ${repositories_auth_url["${repo}"]}
-    build_location_load_repositories_verify_url "request.url" ${repositories_request_url["${repo}"]}
-    build_location_load_repositories_verify_domain "auth.domain" ${repositories_auth_registry["${repo}"]}
+    build_location_load_repositories_verify_url "auth.url" "${repositories_auth_url[${repo}]}"
+    build_location_load_repositories_verify_url "request.url" "${repositories_request_url[${repo}]}"
+    build_location_load_repositories_verify_domain "auth.domain" "${repositories_auth_registry[${repo}]}"
 
     if [[ ${result} -ne 0 ]] ; then return ; fi
 
@@ -458,7 +465,7 @@ build_location_load_repositories_verify_domain() {
   local key=${1}
   local value=${2}
 
-  if [[ $(echo ${value} | grep -sho '[/\:&?]') != "" ]] ; then
+  if [[ $(grep -sho '[/\:&?]' <<< ${value}) != "" ]] ; then
     echo "${p_e}The ${repo} ${key} domain value has unsupported characters ('/', '\', ':', '&', and '?'): ${value} ."
 
     let result=1
@@ -543,7 +550,7 @@ build_location_operate() {
         build_location_print_debug "Skipping all future '${repo}' repository requests due to reaching request rate limit of ${limit} for the request URL: ${request_url}"
 
         # Remove the repo from the active repositories list.
-        repositories_active=$(echo "${repositories_active}" | sed -e "s|\<${repo}\>||g")
+        repositories_active=$(sed -e "s|\<${repo}\>||g" <<< "${repositories_active}")
 
         continue
       fi
@@ -568,7 +575,7 @@ build_location_operate() {
     done
 
     # Terminate loop if there are no active repositories left.
-    if [[ $(echo "${repositories_active}" | sed -e 's|\s||g') == "" ]] ; then break ; fi
+    if [[ $(sed -e 's|\s||g' <<< ${repositories_active}) == "" ]] ; then break ; fi
   done
 
   for repo in ${requests_distinct} ; do
@@ -658,7 +665,7 @@ build_location_operate_request() {
   build_location_handle_result "Curl request failed for repository '${repo}', release '${release}', and tag '${tag}' for: ${full_url}"
 
   if [[ ${result} -eq 0 ]] ; then
-    http_status=$(echo ${request_manifest} | grep -shoi "^http/.*" | grep -shoi "200 ok")
+    http_status=$(grep -shoi "^http/.*" <<< ${request_manifest} | grep -shoi "200 ok")
 
     if [[ ${http_status} != "" ]] ; then
       let found=1
@@ -694,7 +701,7 @@ build_location_parse_release() {
     message=" from JSON: ${file}"
   fi
 
-  release=$(echo -n ${release_with_version} | sed -e "s|-SNAPSHOT*||" -e "s|-[^-]*$||")
+  release=$(sed -e 's|-SNAPSHOT*||' -e 's|-[^-]*$||' <<< ${release_with_version})
 
   build_location_handle_result "Failed to parse release name from '${release_with_version}'${message}"
 }

--- a/script/build_module_discovery.sh
+++ b/script/build_module_discovery.sh
@@ -38,8 +38,8 @@ main() {
 
   build_mod_disc_load_environment ${*}
 
-  build_mod_disc_verify_json "input file" ${file_input}
-  build_mod_disc_verify_output "output file" ${file_output}
+  build_mod_disc_verify_json "input file" "${file_input}"
+  build_mod_disc_verify_output "output file" "${file_output}"
 
   build_mod_disc_build
 
@@ -73,7 +73,7 @@ build_mod_disc_build() {
 
   json="${json} \"discovery\": ["
 
-  build_mod_disc_handle_result ${fail_message}
+  build_mod_disc_handle_result "${fail_message}"
 
   if [[ ${result} -ne 0 ]] ; then return ; fi
 
@@ -99,7 +99,7 @@ build_mod_disc_build() {
       field_name="${version}"
     fi
 
-    field_name=$(echo "${field_name}" | sed -e 's|\.|-|g')
+    field_name=$(sed -e 's|\.|-|g' <<< ${field_name})
 
     json="${json} {"
     json="${json} \"location\": \"${url_prefix}${field_name}${url_suffix}\","
@@ -154,9 +154,9 @@ build_mod_disc_build_write() {
 
   # Prevent jq from printing JSON if ${null} exists when not debugging.
   if [[ ${debug_json} != "" || ! -e ${null} ]] ; then
-    jq -r -M . > ${file_output} <<< ${json}
+    jq -r -M . > "${file_output}" <<< ${json}
   else
-    jq -r -M . > ${file_output} <<< ${json} 2> ${null}
+    jq -r -M . > "${file_output}" <<< ${json} 2> ${null}
   fi
 
   build_mod_disc_handle_result "Failed to write to the output JSON file: ${file_output}"
@@ -194,14 +194,14 @@ build_mod_disc_load_environment() {
   if [[ ${BUILD_MOD_DISCOVERY_DEBUG} != "" ]] ; then
     debug="-v"
 
-    if [[ $(echo ${BUILD_MOD_DISCOVERY_DEBUG} | grep -sho "^\s*json\s*$") != "" ]] ; then
+    if [[ $(grep -sho "^\s*json\s*$" <<< ${BUILD_MOD_DISCOVERY_DEBUG}) != "" ]] ; then
       debug_json="y"
-    elif [[ $(echo ${BUILD_MOD_DISCOVERY_DEBUG} | grep -sho "^\s*json_only\s*$") != "" ]] ; then
+    elif [[ $(grep -sho "^\s*json_only\s*$" <<< ${BUILD_MOD_DISCOVERY_DEBUG}) != "" ]] ; then
       debug=
       debug_json="y"
-    elif [[ $(echo ${BUILD_MOD_DISCOVERY_DEBUG} | grep -sho "_only") != "" ]] ; then
+    elif [[ $(grep -sho "_only" <<< ${BUILD_MOD_DISCOVERY_DEBUG}) != "" ]] ; then
       debug=
-    elif [[ $(echo ${BUILD_MOD_DISCOVERY_DEBUG} | grep -sho "\<json\>") != "" ]] ; then
+    elif [[ $(grep -sho "\<json\>" <<< ${BUILD_MOD_DISCOVERY_DEBUG}) != "" ]] ; then
       debug_json="y"
     fi
   fi
@@ -255,9 +255,9 @@ build_mod_disc_verify_json() {
   else
     # Prevent jq from printing JSON if ${null} exists when not debugging.
     if [[ ${debug_json} != "" || ! -e ${null} ]] ; then
-      jq < ${file}
+      jq < "${file}"
     else
-      jq < ${file} >> ${null} 2>&1
+      jq < "${file}" >> ${null} 2>&1
     fi
 
     let result=${?}

--- a/script/build_module_discovery.sh
+++ b/script/build_module_discovery.sh
@@ -194,14 +194,14 @@ build_mod_disc_load_environment() {
   if [[ ${BUILD_MOD_DISCOVERY_DEBUG} != "" ]] ; then
     debug="-v"
 
-    if [[ $(grep -sho "^\s*json\s*$" <<< ${BUILD_MOD_DISCOVERY_DEBUG}) != "" ]] ; then
+    if [[ $(grep -sho '^\s*json\s*$' <<< ${BUILD_MOD_DISCOVERY_DEBUG}) != "" ]] ; then
       debug_json="y"
-    elif [[ $(grep -sho "^\s*json_only\s*$" <<< ${BUILD_MOD_DISCOVERY_DEBUG}) != "" ]] ; then
+    elif [[ $(grep -sho '^\s*json_only\s*$' <<< ${BUILD_MOD_DISCOVERY_DEBUG}) != "" ]] ; then
       debug=
       debug_json="y"
-    elif [[ $(grep -sho "_only" <<< ${BUILD_MOD_DISCOVERY_DEBUG}) != "" ]] ; then
+    elif [[ $(grep -sho '_only' <<< ${BUILD_MOD_DISCOVERY_DEBUG}) != "" ]] ; then
       debug=
-    elif [[ $(grep -sho "\<json\>" <<< ${BUILD_MOD_DISCOVERY_DEBUG}) != "" ]] ; then
+    elif [[ $(grep -sho '\<json\>' <<< ${BUILD_MOD_DISCOVERY_DEBUG}) != "" ]] ; then
       debug_json="y"
     fi
   fi

--- a/script/build_pages.sh
+++ b/script/build_pages.sh
@@ -81,21 +81,21 @@ build_page_load_environment() {
   if [[ ${BUILD_PAGES_DEBUG} != "" ]] ; then
     debug="-v"
 
-    if [[ $(echo ${BUILD_PAGES_DEBUG} | grep -sho "^\s*json\s*$") != "" ]] ; then
+    if [[ $(grep -sho "^\s*json\s*$" <<< ${BUILD_PAGES_DEBUG}) != "" ]] ; then
       debug_json="y"
-    elif [[ $(echo ${BUILD_PAGES_DEBUG} | grep -sho "^\s*verify\s*$") != "" ]] ; then
+    elif [[ $(grep -sho "^\s*verify\s*$" <<< ${BUILD_PAGES_DEBUG}) != "" ]] ; then
       debug_verify="y"
-    elif [[ $(echo ${BUILD_PAGES_DEBUG} | grep -sho "^\s*json_only\s*$") != "" ]] ; then
+    elif [[ $(grep -sho "^\s*json_only\s*$" <<< ${BUILD_PAGES_DEBUG}) != "" ]] ; then
       debug=
       debug_json="y"
-    elif [[ $(echo ${BUILD_PAGES_DEBUG} | grep -sho "_only") != "" ]] ; then
+    elif [[ $(grep -sho "_only" <<< ${BUILD_PAGES_DEBUG}) != "" ]] ; then
       debug=
     else
-      if [[ $(echo ${BUILD_PAGES_DEBUG} | grep -sho "\<json\>") != "" ]] ; then
+      if [[ $(grep -sho "\<json\>" <<< ${BUILD_PAGES_DEBUG}) != "" ]] ; then
         debug_json="y"
       fi
 
-      if [[ $(echo ${BUILD_PAGES_DEBUG} | grep -sho "\<verify\>") != "" ]] ; then
+      if [[ $(grep -sho "\<verify\>" <<< ${BUILD_PAGES_DEBUG}) != "" ]] ; then
         debug_verify="y"
       fi
     fi
@@ -103,10 +103,10 @@ build_page_load_environment() {
 
   # May be empty, so use "-v" test rather than != "".
   if [[ -v BUILD_PAGES_BASE ]] ; then
-    if [[ $(echo ${BUILD_PAGES_BASE} | sed -e "s|\s||g") == "" ]] ; then
+    if [[ $(sed -e 's|\s||g' <<< ${BUILD_PAGES_BASE}) == "" ]] ; then
       base=
     else
-      base=$(echo ${BUILD_PAGES_BASE} | sed -e 's|/*$|/|g')
+      base=$(sed -e 's|/*$|/|g' <<< ${BUILD_PAGES_BASE})
     fi
   fi
 
@@ -115,19 +115,19 @@ build_page_load_environment() {
   fi
 
   if [[ ${BUILD_PAGES_TEMPLATE_BACK} != "" ]] ; then
-    template_back=$(echo ${BUILD_PAGES_TEMPLATE_BACK} | sed -e 's|//*|/|g' -e 's|/*$||g')
+    template_back=$(sed -e 's|//*|/|g' -e 's|/*$||g' <<< ${BUILD_PAGES_TEMPLATE_BACK})
   fi
 
   if [[ ${BUILD_PAGES_TEMPLATE_BASE} != "" ]] ; then
-    template_base=$(echo ${BUILD_PAGES_TEMPLATE_BASE} | sed -e 's|//*|/|g' -e 's|/*$||g')
+    template_base=$(sed -e 's|//*|/|g' -e 's|/*$||g' <<< ${BUILD_PAGES_TEMPLATE_BASE})
   fi
 
   if [[ ${BUILD_PAGES_TEMPLATE_ITEM} != "" ]] ; then
-    template_item=$(echo ${BUILD_PAGES_TEMPLATE_ITEM} | sed -e 's|//*|/|g' -e 's|/*$||g')
+    template_item=$(sed -e 's|//*|/|g' -e 's|/*$||g' <<< ${BUILD_PAGES_TEMPLATE_ITEM})
   fi
 
   if [[ ${BUILD_PAGES_TEMPLATE_PATH} != "" ]] ; then
-    template_path=$(echo ${BUILD_PAGES_TEMPLATE_PATH} | sed -e 's|//*|/|g' -e 's|/*$|/|g')
+    template_path=$(sed -e 's|//*|/|g' -e 's|/*$|/|g' <<< ${BUILD_PAGES_TEMPLATE_PATH})
   fi
 
   if [[ ! -d ${template_path} ]] ; then
@@ -155,7 +155,7 @@ build_page_load_environment() {
   fi
 
   if [[ ${BUILD_PAGES_WORK} != "" ]] ; then
-    work=$(echo ${BUILD_PAGES_WORK} | sed -e 's|//*|/|g' -e 's|/*$|/|g')
+    work=$(sed -e 's|//*|/|g' -e 's|/*$|/|g' <<< ${BUILD_PAGES_WORK})
   fi
 
   if [[ -e ${work} && ! -d ${work} ]] ; then
@@ -166,11 +166,11 @@ build_page_load_environment() {
 
   if [[ ${result} -ne 0 ]] ; then return ; fi
 
-  template_back_data=$(< ${template_path}${template_back})
-  template_item_data=$(< ${template_path}${template_item})
+  template_back_data=$(< "${template_path}${template_back}")
+  template_item_data=$(< "${template_path}${template_item}")
 
   if [[ ! -d ${work} ]] ; then
-    mkdir ${debug} -p ${work}
+    mkdir ${debug} -p "${work}"
 
     build_page_handle_result "Failed to create work directory: ${work}"
   fi
@@ -182,7 +182,7 @@ build_page_load_environment() {
       let i=${i}+1
       parameter=${!i}
 
-      file=$(echo ${parameter} | sed -e 's|//*|/|' -e 's|/*$|/|')
+      file=$(sed -e 's|//*|/|' -e 's|/*$|/|' <<< ${parameter})
 
       if [[ ! -d ${file} ]] ; then
         echo "${p_e}The following path is not a valid descriptor source directory: ${file} ."
@@ -201,15 +201,13 @@ build_page_operate() {
 
   if [[ ${result} -ne 0 ]] ; then return ; fi
 
-  local index=${work}/index.html
+  local index="${work}/index.html"
   local indexes=
 
   build_page_operate_sources
 
   build_page_operate_index_setup
-
   build_page_operate_index_expand "${index}" "${title_main}"
-
   build_page_operate_index_finalize "${index}" "${indexes}"
 
   if [[ ${result} -ne 0 ]] ; then return ; fi
@@ -227,8 +225,8 @@ build_page_operate_index_expand() {
   local back=
 
   if [[ ${3} == "back" ]] ; then
-    if [[ $(echo ${template_back_data} | sed -e "s|\s||g") != "" ]] ; then
-      back=$(echo ${template_back_data} | sed -e "s|\<_REPLACE_LINK_\>||g" -e "s|\<_REPLACE_SECTION_TITLE_\>|${title_main}|g")
+    if [[ $(sed -e 's|\s||g' <<< ${template_back_data}) != "" ]] ; then
+      back=$(sed -e 's|\<_REPLACE_LINK_\>||g' -e "s|\<_REPLACE_SECTION_TITLE_\>|${title_main}|g" <<< ${template_back_data})
     fi
   fi
 
@@ -239,7 +237,7 @@ build_page_operate_index_expand() {
     -e "s|\<_REPLACE_SECTION_TITLE_\>|${title}|g" \
     -e "s|\<_REPLACE_SECTION_DATE_\>|${now}|g" \
     -e "s|\s*\<_REPLACE_EOL_\>\s*|\n|g" \
-    ${index}
+    "${index}"
 
   build_page_handle_result "Failed to expand common template variables in ${index}"
 }
@@ -254,7 +252,7 @@ build_page_operate_index_finalize() {
   sed -i \
     -e "s|\<_REPLACE_SECTION_SNIPPET_\>|${snippet}|g" \
     -e "s|\s*\<_REPLACE_EOL_\>\s*|\n|g" \
-    ${index}
+    "${index}"
 
   build_page_handle_result "Failed to expand final template variables in ${index}"
 }
@@ -263,11 +261,11 @@ build_page_operate_index_setup() {
 
   if [[ ${result} -ne 0 ]] ; then return ; fi
 
-  if [[ $(echo ${indexes} | sed -e "s|\s||g") == "" ]] ; then
+  if [[ $(sed -e 's|\s||g' <<< ${indexes}) == "" ]] ; then
     indexes="There are no releases available to index."
   fi
 
-  cp ${debug} ${template_path}${template_base} ${work}/index.html
+  cp ${debug} "${template_path}${template_base}" "${work}/index.html"
 
   build_page_handle_result "Failed to copy ${template_path}${template_item} to ${work}/index.html"
 }
@@ -285,13 +283,13 @@ build_page_operate_sources() {
     echo
     echo "Operating on source: ${i} ."
 
-    find ${i} -mindepth 1 -maxdepth 1 -printf "%p\n" | sort -u | while read -d $'\n' j ; do
+    find "${i}" -mindepth 1 -maxdepth 1 -printf "%p\n" | sort -u | while read -d $'\n' j ; do
       source=$(basename ${j})
 
       echo
       echo "Operating on source ${i} work source sub-directory: ${source} ."
 
-      mkdir ${debug} -p ${work}${source}
+      mkdir ${debug} -p "${work}${source}"
 
       build_page_handle_result "Failed to create work source sub-directory: ${work}${source}"
 
@@ -299,7 +297,6 @@ build_page_operate_sources() {
       if [[ $(ls ${j}/) == "" ]] ; then continue ; fi
 
       build_page_operate_sources_process_index_template_item
-
       build_page_operate_sources_index_setup
 
       build_page_operate_index_expand "${work}${source}/index.html" "Listing of ${source} Release" back
@@ -317,9 +314,9 @@ build_page_operate_sources_index_setup() {
 
   if [[ ${result} -ne 0 ]] ; then return ; fi
 
-  local index=${work}${source}/index.html
+  local index="${work}${source}/index.html"
 
-  cp ${debug} ${template_path}${template_base} ${index}
+  cp ${debug} "${template_path}${template_base}" "${index}"
 
   build_page_handle_result "Failed to copy ${template_path}${template_item} to ${index}"
 }
@@ -332,10 +329,10 @@ build_page_operate_sources_process_files() {
   local files=
   local k=
 
-  find ${j} -mindepth 1 -maxdepth 1 -printf "%p\n" | sort -u | while read -d $'\n' k ; do
+  find "${j}" -mindepth 1 -maxdepth 1 -printf "%p\n" | sort -u | while read -d $'\n' k ; do
     file=$(basename ${k})
 
-    if [[ $(echo -n ${file} | grep -sho "^\.") != "" ]] ; then
+    if [[ $(grep -sho "^\." <<< ${file}) != "" ]] ; then
       build_page_print_debug_verify "Skipping work source sub-directory ${source} hidden file: ${file}"
 
       continue
@@ -354,9 +351,7 @@ build_page_operate_sources_process_files() {
     fi
 
     build_page_operate_sources_process_files_verify_file
-
     build_page_operate_sources_process_files_copy_file
-
     build_page_operate_sources_process_files_index_item
 
     # Reset error for each loop pass, the problems represents the final error state.
@@ -380,7 +375,7 @@ build_page_operate_sources_process_files_copy_file() {
 
   if [[ ${result} -ne 0 ]] ; then return ; fi
 
-  cp ${debug} ${k} ${work}${source}/${file}
+  cp ${debug} "${k}" "${work}${source}/${file}"
 
   build_page_handle_result "Failed to copy ${k} to ${work}${source}/${file}"
 }
@@ -389,10 +384,10 @@ build_page_operate_sources_process_files_index_item() {
 
   if [[ ${result} -ne 0 ]] ; then return ; fi
 
-  local item=$(echo ${template_item_data} | sed -e "s|\<_REPLACE_LINK_\>|${source}/${file}|g" -e "s|\<_REPLACE_LINK_NAME_\>|${file}|g" -e "s|\<_REPLACE_LINK_TYPE_\>|type="application/json"|g" -e "s|\<_REPLACE_LINK_DOWNLOAD_\>|download="${file}.json"|g")
+  local item=$(sed -e "s|\<_REPLACE_LINK_\>|${source}/${file}|g" -e "s|\<_REPLACE_LINK_NAME_\>|${file}|g" -e "s|\<_REPLACE_LINK_TYPE_\>|type="application/json"|g" -e "s|\<_REPLACE_LINK_DOWNLOAD_\>|download="${file}.json"|g" <<< ${template_item_data})
 
   # Expand the variable, but re-introduce the snippet on each run to allow replacements for each item.
-  sed -i -e "s|\<_REPLACE_SECTION_SNIPPET_\>|${item}\n&|g" ${work}${source}/index.html
+  sed -i -e "s|\<_REPLACE_SECTION_SNIPPET_\>|${item}\n&|g" "${work}${source}/index.html"
 
   build_page_handle_result "Failed to expand item '${file}' template variables in ${work}${source}/index.html"
 }
@@ -403,9 +398,9 @@ build_page_operate_sources_process_files_verify_file() {
 
   # Prevent jq from printing JSON if ${null} exists when not debugging.
   if [[ ${debug_json} != "" || ! -e ${null} ]] ; then
-    jq . ${k}
+    jq . "${k}"
   else
-    jq . ${k} >> ${null}
+    jq . "${k}" >> ${null}
   fi
 
   let result=${?}
@@ -425,7 +420,7 @@ build_page_operate_sources_process_index_template_item() {
 
   local item=
 
-  item=$(echo ${template_item_data} | sed -e "s|\<_REPLACE_LINK_\>|${source}/|g" -e "s|\<_REPLACE_LINK_NAME_\>|${source}|g" -e "s|\<_REPLACE_LINK_TYPE_\>||g" -e "s|\<_REPLACE_LINK_DOWNLOAD_\>||g")
+  item=$(sed -e "s|\<_REPLACE_LINK_\>|${source}/|g" -e "s|\<_REPLACE_LINK_NAME_\>|${source}|g" -e "s|\<_REPLACE_LINK_TYPE_\>||g" -e "s|\<_REPLACE_LINK_DOWNLOAD_\>||g" <<< ${template_item_data})
 
   indexes="${indexes}${item}_REPLACE_EOL_ "
 }

--- a/script/build_pages.sh
+++ b/script/build_pages.sh
@@ -81,21 +81,21 @@ build_page_load_environment() {
   if [[ ${BUILD_PAGES_DEBUG} != "" ]] ; then
     debug="-v"
 
-    if [[ $(grep -sho "^\s*json\s*$" <<< ${BUILD_PAGES_DEBUG}) != "" ]] ; then
+    if [[ $(grep -sho '^\s*json\s*$' <<< ${BUILD_PAGES_DEBUG}) != "" ]] ; then
       debug_json="y"
-    elif [[ $(grep -sho "^\s*verify\s*$" <<< ${BUILD_PAGES_DEBUG}) != "" ]] ; then
+    elif [[ $(grep -sho '^\s*verify\s*$' <<< ${BUILD_PAGES_DEBUG}) != "" ]] ; then
       debug_verify="y"
-    elif [[ $(grep -sho "^\s*json_only\s*$" <<< ${BUILD_PAGES_DEBUG}) != "" ]] ; then
+    elif [[ $(grep -sho '^\s*json_only\s*$' <<< ${BUILD_PAGES_DEBUG}) != "" ]] ; then
       debug=
       debug_json="y"
-    elif [[ $(grep -sho "_only" <<< ${BUILD_PAGES_DEBUG}) != "" ]] ; then
+    elif [[ $(grep -sho '_only' <<< ${BUILD_PAGES_DEBUG}) != "" ]] ; then
       debug=
     else
-      if [[ $(grep -sho "\<json\>" <<< ${BUILD_PAGES_DEBUG}) != "" ]] ; then
+      if [[ $(grep -sho '\<json\>' <<< ${BUILD_PAGES_DEBUG}) != "" ]] ; then
         debug_json="y"
       fi
 
-      if [[ $(grep -sho "\<verify\>" <<< ${BUILD_PAGES_DEBUG}) != "" ]] ; then
+      if [[ $(grep -sho '\<verify\>' <<< ${BUILD_PAGES_DEBUG}) != "" ]] ; then
         debug_verify="y"
       fi
     fi
@@ -332,7 +332,7 @@ build_page_operate_sources_process_files() {
   find "${j}" -mindepth 1 -maxdepth 1 -printf "%p\n" | sort -u | while read -d $'\n' k ; do
     file=$(basename ${k})
 
-    if [[ $(grep -sho "^\." <<< ${file}) != "" ]] ; then
+    if [[ $(grep -sho '^\.' <<< ${file}) != "" ]] ; then
       build_page_print_debug_verify "Skipping work source sub-directory ${source} hidden file: ${file}"
 
       continue

--- a/script/populate_node.sh
+++ b/script/populate_node.sh
@@ -48,7 +48,7 @@ main() {
   local debug_json=
   local debug_yarn="-s"
   local destination=
-  local npm_dir=$(echo ${PWD} | sed -e 's|/*$|/|')
+  local npm_dir=$(sed -e 's|/*$|/|' <<< ${PWD})
   local npm_file="npm.json"
   local null="/dev/null"
   local projects="@folio/authorization-policies @folio/authorization-roles"
@@ -61,9 +61,9 @@ main() {
   local -i result=0
   local -i skip_bad=0
 
-  destination=${npm_dir}release/snapshot/
+  destination="${npm_dir}release/snapshot/"
 
-  pop_node_load_environment
+  pop_node_load_environment ${*}
 
   pop_node_verify_files
 
@@ -89,42 +89,42 @@ pop_node_load_environment() {
     debug_json=
     debug_yarn="-s"
 
-    if [[ $(echo ${POPULATE_NODE_DEBUG} | grep -sho "^\s*json\s*$") != "" ]] ; then
+    if [[ $(grep -sho "^\s*json\s*$" <<< ${POPULATE_NODE_DEBUG}) != "" ]] ; then
       debug_json="y"
-    elif [[ $(echo ${POPULATE_NODE_DEBUG} | grep -sho "^\s*yarn\s*$") != "" ]] ; then
+    elif [[ $(grep -sho "^\s*yarn\s*$" <<< ${POPULATE_NODE_DEBUG}) != "" ]] ; then
       debug_yarn="--verbose"
-    elif [[ $(echo ${POPULATE_NODE_DEBUG} | grep -sho "^\s*json_only\s*$") != "" ]] ; then
+    elif [[ $(grep -sho "^\s*json_only\s*$" <<< ${POPULATE_NODE_DEBUG}) != "" ]] ; then
       debug=
       debug_json="y"
-    elif [[ $(echo ${POPULATE_NODE_DEBUG} | grep -sho "^\s*yarn_only\s*$") != "" ]] ; then
+    elif [[ $(grep -sho "^\s*yarn_only\s*$" <<< ${POPULATE_NODE_DEBUG}) != "" ]] ; then
       debug=
       debug_yarn="--verbose"
-    elif [[ $(echo ${POPULATE_NODE_DEBUG} | grep -sho "_only") != "" ]] ; then
+    elif [[ $(grep -sho "_only" <<< ${POPULATE_NODE_DEBUG}) != "" ]] ; then
       debug=
     else
-      if [[ $(echo ${POPULATE_NODE_DEBUG} | grep -sho "\<json\>") != "" ]] ; then
+      if [[ $(grep -sho "\<json\>" <<< ${POPULATE_NODE_DEBUG}) != "" ]] ; then
         debug_json="y"
       fi
 
-      if [[ $(echo ${POPULATE_NODE_DEBUG} | grep -sho "\<yarn\>") != "" ]] ; then
+      if [[ $(grep -sho "\<yarn\>" <<< ${POPULATE_NODE_DEBUG}) != "" ]] ; then
         debug_yarn="--verbose"
       fi
     fi
   fi
 
-  if [[ $(echo -n ${POPULATE_NODE_DESTINATION} | sed -e 's|\s||g') != "" ]] ; then
-    destination=$(echo -n ${POPULATE_NODE_DESTINATION} | sed -e 's|//*|/|g' -e 's|/*$|/|g')
+  if [[ $(sed -e 's|\s||g' <<< ${POPULATE_NODE_DESTINATION}) != "" ]] ; then
+    destination=$(sed -e 's|//*|/|g' -e 's|/*$|/|g' <<< ${POPULATE_NODE_DESTINATION})
   fi
 
-  if [[ $(echo -n ${POPULATE_NODE_NPM_DIR} | sed -e 's|\s||g') != "" ]] ; then
-    npm_dir=$(echo -n ${POPULATE_NODE_NPM_DIR} | sed -e 's|//*|/|g' -e 's|/*$|/|g')
+  if [[ $(sed -e 's|\s||g' <<< ${POPULATE_NODE_NPM_DIR}) != "" ]] ; then
+    npm_dir=$(sed -e 's|//*|/|g' -e 's|/*$|/|g' <<< ${POPULATE_NODE_NPM_DIR})
   fi
 
   if [[ ${POPULATE_NODE_NPM_FILE} != "" ]] ; then
-    npm_file=$(echo -n ${POPULATE_NODE_NPM_FILE} | sed -e 's|//*|/|g' -e 's|/*$||g')
+    npm_file=$(sed -e 's|//*|/|g' -e 's|/*$||g' <<< ${POPULATE_NODE_NPM_FILE})
   fi
 
-  if [[ $(echo -n ${POPULATE_NODE_PROJECTS} | sed -e 's|\s||g') != "" ]] ; then
+  if [[ $(sed -e 's|\s||g' <<< ${POPULATE_NODE_PROJECTS}) != "" ]] ; then
     projects=
 
     for project in ${POPULATE_NODE_PROJECTS} ; do
@@ -132,18 +132,18 @@ pop_node_load_environment() {
     done
   fi
 
-  if [[ $(echo -n ${POPULATE_NODE_SKIP_BAD} | sed -e 's|\s||g') != "" ]] ; then
+  if [[ $(sed -e 's|\s||g' <<< ${POPULATE_NODE_SKIP_BAD}) != "" ]] ; then
     let skip_bad=1
   fi
 
   if [[ ${POPULATE_NODE_WORKSPACE} != "" ]] ; then
-    workspace=$(echo -n ${POPULATE_NODE_WORKSPACE} | sed -e 's|//*|/|g' -e 's|/*$|/|g')
+    workspace=$(sed -e 's|//*|/|g' -e 's|/*$|/|g' <<< ${POPULATE_NODE_WORKSPACE})
 
     # If the workspace path is relative, make it absolute.
-    if [[ $(echo ${workspace} | grep -sho '^/') == "" ]] ; then
+    if [[ $(grep -sho '^/' <<< ${workspace}) == "" ]] ; then
       workspace="${PWD}/${workspace}"
-    elif [[ $(echo ${workspace} | grep -sho '^\./') != "" ]] ; then
-      workspace=$(echo -n ${workspace} | sed -e "s|^\./|${PWD}/|")
+    elif [[ $(grep -sho '^\./' <<< ${workspace}) != "" ]] ; then
+      workspace=$(sed -e "s|^\./|${PWD}/|" <<< ${workspace})
     fi
   fi
 }
@@ -172,7 +172,7 @@ pop_node_process_projects() {
 
   for project in ${projects} ; do
 
-    project_simple=$(echo -n ${project} | sed -e 's|^.*/||')
+    project_simple=$(sed -e 's|^.*/||' <<< ${project})
     version=
 
     echo
@@ -225,10 +225,10 @@ pop_node_process_projects_copy_descriptor() {
 
   if [[ ${result} -ne 0 ]] ; then return ; fi
 
-  local name=folio_${project}
+  local name="folio_${project}"
   local release="${destination}folio_${project_simple}-${version}"
 
-  cp ${debug} module-descriptor.json ${release}
+  cp ${debug} module-descriptor.json "${release}"
 
   pop_node_handle_result "Failed to copy the module descriptor for the ${project} (simple: ${project_simple}) to: ${release}"
 }
@@ -300,14 +300,14 @@ pop_node_process_projects_update_npm_json() {
   if [[ ! -f ${npm_dir}${npm_file} ]] ; then
     pop_node_print_debug "echo \"[{ \\\"id\\\": \\\"folio_${project_simple}-${version}\\\", \\\"action\\\": \\\"enable\\\" }]\" > ${npm_dir}${npm_file}"
 
-    echo "[{ \"id\": \"folio_${project_simple}-${version}\", \"action\": \"enable\" }]" > ${npm_dir}${npm_file}
+    echo "[{ \"id\": \"folio_${project_simple}-${version}\", \"action\": \"enable\" }]" > "${npm_dir}${npm_file}"
   else
     # Work around JQ's problems with using the input as the output.
     local json=$(< ${npm_dir}${npm_file})
 
     pop_node_print_debug "jq \". |= . + [{ \\\"id\\\": \\\"folio_${project_simple}-${version}\\\", \\\"action\\\": \\\"enable\\\" }]\" <<< ${json} > ${npm_dir}${npm_file}"
 
-    jq ". |= . + [{ \"id\": \"folio_${project_simple}-${version}\", \"action\": \"enable\" }]" <<< ${json} > ${npm_dir}${npm_file}
+    jq ". |= . + [{ \"id\": \"folio_${project_simple}-${version}\", \"action\": \"enable\" }]" <<< ${json} > "${npm_dir}${npm_file}"
   fi
 
   pop_node_handle_result "Failed to add the version (${version}) for the project ${project} (simple: ${project_simple}) to: ${npm_dir}${npm_file}"
@@ -321,9 +321,7 @@ pop_node_verify_files() {
   local workspace_json="{ \"name\": \"workspace\", \"private\": true, \"version\": \"1.0.0\", \"workspaces\": [ \"*\" ], \"dependencies\": { } }"
 
   pop_node_verify_files_workspace
-
   pop_node_verify_files_workspace_file
-
   pop_node_verify_files_workspace_file_json
 
   pop_node_verify_files_npm_file
@@ -345,7 +343,7 @@ pop_node_verify_files_destination() {
     return
   fi
 
-  mkdir ${debug} -p ${destination}
+  mkdir ${debug} -p "${destination}"
 
   pop_node_handle_result "Failed to create destination directory: ${destination}"
 }
@@ -365,7 +363,7 @@ pop_node_verify_files_npm_file() {
   fi
 
   # Re-create the NPM file on each run of this script.
-  rm ${debug} -f ${npm_dir}${npm_file}
+  rm ${debug} -f "${npm_dir}${npm_file}"
 
   pop_node_handle_result "Failed to create NPM JSON file: ${npm_dir}${npm_file}"
 }
@@ -383,7 +381,7 @@ pop_node_verify_files_workspace() {
       let result=1
     fi
   elif [[ ! -d ${workspace} ]] ; then
-    mkdir ${debug} -p ${workspace}
+    mkdir ${debug} -p "${workspace}"
 
     pop_node_handle_result "Failed to create workspace directory: ${workspace}"
   fi
@@ -400,7 +398,7 @@ pop_node_verify_files_workspace_file() {
       let result=1
     fi
   else
-    echo ${workspace_json} > ${workspace_file}
+    echo "${workspace_json}" > "${workspace_file}"
 
     pop_node_handle_result "Failed to create workspace file: ${workspace_file}"
   fi
@@ -412,9 +410,9 @@ pop_node_verify_files_workspace_file_json() {
 
   # Prevent jq from printing JSON if ${null} exists when not debugging.
   if [[ ${debug_json} != "" || ! -e ${null} ]] ; then
-    jq . ${workspace_file}
+    jq . "${workspace_file}"
   else
-    jq . ${workspace_file} >> ${null}
+    jq . "${workspace_file}" >> ${null}
   fi
 
   pop_node_handle_result "Invalid workspace JSON file: ${workspace_file}"

--- a/script/populate_node.sh
+++ b/script/populate_node.sh
@@ -89,24 +89,24 @@ pop_node_load_environment() {
     debug_json=
     debug_yarn="-s"
 
-    if [[ $(grep -sho "^\s*json\s*$" <<< ${POPULATE_NODE_DEBUG}) != "" ]] ; then
+    if [[ $(grep -sho '^\s*json\s*$' <<< ${POPULATE_NODE_DEBUG}) != "" ]] ; then
       debug_json="y"
-    elif [[ $(grep -sho "^\s*yarn\s*$" <<< ${POPULATE_NODE_DEBUG}) != "" ]] ; then
+    elif [[ $(grep -sho '^\s*yarn\s*$' <<< ${POPULATE_NODE_DEBUG}) != "" ]] ; then
       debug_yarn="--verbose"
-    elif [[ $(grep -sho "^\s*json_only\s*$" <<< ${POPULATE_NODE_DEBUG}) != "" ]] ; then
+    elif [[ $(grep -sho '^\s*json_only\s*$' <<< ${POPULATE_NODE_DEBUG}) != "" ]] ; then
       debug=
       debug_json="y"
-    elif [[ $(grep -sho "^\s*yarn_only\s*$" <<< ${POPULATE_NODE_DEBUG}) != "" ]] ; then
+    elif [[ $(grep -sho '^\s*yarn_only\s*$' <<< ${POPULATE_NODE_DEBUG}) != "" ]] ; then
       debug=
       debug_yarn="--verbose"
-    elif [[ $(grep -sho "_only" <<< ${POPULATE_NODE_DEBUG}) != "" ]] ; then
+    elif [[ $(grep -sho '_only' <<< ${POPULATE_NODE_DEBUG}) != "" ]] ; then
       debug=
     else
-      if [[ $(grep -sho "\<json\>" <<< ${POPULATE_NODE_DEBUG}) != "" ]] ; then
+      if [[ $(grep -sho '\<json\>' <<< ${POPULATE_NODE_DEBUG}) != "" ]] ; then
         debug_json="y"
       fi
 
-      if [[ $(grep -sho "\<yarn\>" <<< ${POPULATE_NODE_DEBUG}) != "" ]] ; then
+      if [[ $(grep -sho '\<yarn\>' <<< ${POPULATE_NODE_DEBUG}) != "" ]] ; then
         debug_yarn="--verbose"
       fi
     fi

--- a/script/populate_release.sh
+++ b/script/populate_release.sh
@@ -94,27 +94,27 @@ pop_rel_load_environment() {
     debug_curl=
     debug_json=
 
-    if [[ $(grep -sho "^\s*curl\s*$" <<< ${POPULATE_RELEASE_DEBUG}) != "" ]] ; then
+    if [[ $(grep -sho '^\s*curl\s*$' <<< ${POPULATE_RELEASE_DEBUG}) != "" ]] ; then
       debug_curl="y"
       debug_curl_silent=
-    elif [[ $(grep -sho "^\s*curl_only\s*$" <<< ${POPULATE_RELEASE_DEBUG}) != "" ]] ; then
+    elif [[ $(grep -sho '^\s*curl_only\s*$' <<< ${POPULATE_RELEASE_DEBUG}) != "" ]] ; then
       debug=
       debug_curl="y"
       debug_curl_silent=
-    elif [[ $(grep -sho "^\s*json\s*$" <<< ${POPULATE_RELEASE_DEBUG}) != "" ]] ; then
+    elif [[ $(grep -sho '^\s*json\s*$' <<< ${POPULATE_RELEASE_DEBUG}) != "" ]] ; then
       debug_json="y"
-    elif [[ $(grep -sho "^\s*json_only\s*$" <<< ${POPULATE_RELEASE_DEBUG}) != "" ]] ; then
+    elif [[ $(grep -sho '^\s*json_only\s*$' <<< ${POPULATE_RELEASE_DEBUG}) != "" ]] ; then
       debug=
       debug_json="y"
-    elif [[ $(grep -sho "_only" <<< ${POPULATE_RELEASE_DEBUG}) != "" ]] ; then
+    elif [[ $(grep -sho '_only' <<< ${POPULATE_RELEASE_DEBUG}) != "" ]] ; then
       debug=
     else
-      if [[ $(grep -sho "\<curl\>" <<< ${POPULATE_RELEASE_DEBUG}) != "" ]] ; then
+      if [[ $(grep -sho '\<curl\>' <<< ${POPULATE_RELEASE_DEBUG}) != "" ]] ; then
         debug_curl="y"
         debug_curl_silent=
       fi
 
-      if [[ $(grep -sho "\<json\>" <<< ${POPULATE_RELEASE_DEBUG}) != "" ]] ; then
+      if [[ $(grep -sho '\<json\>' <<< ${POPULATE_RELEASE_DEBUG}) != "" ]] ; then
         debug_json="y"
       fi
     fi

--- a/script/populate_release.sh
+++ b/script/populate_release.sh
@@ -59,7 +59,7 @@ main() {
 
   local -i result=0
 
-  pop_rel_load_environment
+  pop_rel_load_environment ${*}
 
   if [[ ${POPULATE_RELEASE_FILE_REUSE} != "" ]] ; then
     if [[ ! -f ${file} ]] ; then
@@ -94,27 +94,27 @@ pop_rel_load_environment() {
     debug_curl=
     debug_json=
 
-    if [[ $(echo ${POPULATE_RELEASE_DEBUG} | grep -sho "^\s*curl\s*$") != "" ]] ; then
+    if [[ $(grep -sho "^\s*curl\s*$" <<< ${POPULATE_RELEASE_DEBUG}) != "" ]] ; then
       debug_curl="y"
       debug_curl_silent=
-    elif [[ $(echo ${POPULATE_RELEASE_DEBUG} | grep -sho "^\s*curl_only\s*$") != "" ]] ; then
+    elif [[ $(grep -sho "^\s*curl_only\s*$" <<< ${POPULATE_RELEASE_DEBUG}) != "" ]] ; then
       debug=
       debug_curl="y"
       debug_curl_silent=
-    elif [[ $(echo ${POPULATE_RELEASE_DEBUG} | grep -sho "^\s*json\s*$") != "" ]] ; then
+    elif [[ $(grep -sho "^\s*json\s*$" <<< ${POPULATE_RELEASE_DEBUG}) != "" ]] ; then
       debug_json="y"
-    elif [[ $(echo ${POPULATE_RELEASE_DEBUG} | grep -sho "^\s*json_only\s*$") != "" ]] ; then
+    elif [[ $(grep -sho "^\s*json_only\s*$" <<< ${POPULATE_RELEASE_DEBUG}) != "" ]] ; then
       debug=
       debug_json="y"
-    elif [[ $(echo ${POPULATE_RELEASE_DEBUG} | grep -sho "_only") != "" ]] ; then
+    elif [[ $(grep -sho "_only" <<< ${POPULATE_RELEASE_DEBUG}) != "" ]] ; then
       debug=
     else
-      if [[ $(echo ${POPULATE_RELEASE_DEBUG} | grep -sho "\<curl\>") != "" ]] ; then
+      if [[ $(grep -sho "\<curl\>" <<< ${POPULATE_RELEASE_DEBUG}) != "" ]] ; then
         debug_curl="y"
         debug_curl_silent=
       fi
 
-      if [[ $(echo ${POPULATE_RELEASE_DEBUG} | grep -sho "\<json\>") != "" ]] ; then
+      if [[ $(grep -sho "\<json\>" <<< ${POPULATE_RELEASE_DEBUG}) != "" ]] ; then
         debug_json="y"
       fi
     fi
@@ -140,14 +140,14 @@ pop_rel_load_environment() {
   fi
 
   if [[ ${POPULATE_RELEASE_DESTINATION} != "" ]] ; then
-    destination=$(echo ${POPULATE_RELEASE_DESTINATION} | sed -e 's|//*|/|g' -e 's|/*$|/|g')
+    destination=$(sed -e 's|//*|/|g' -e 's|/*$|/|g' <<< ${POPULATE_RELEASE_DESTINATION})
   fi
 
-  if [[ $(echo ${POPULATE_RELEASE_FILES} | sed -e 's|\s||g') != "" ]] ; then
+  if [[ $(sed -e 's|\s||g' <<< ${POPULATE_RELEASE_FILES}) != "" ]] ; then
     files=
 
     for i in ${POPULATE_RELEASE_FILES} ; do
-      file=$(echo ${POPULATE_RELEASE_FILES} | sed -e 's|//*|/|g' -e 's|/*$||')
+      file=$(sed -e 's|//*|/|g' -e 's|/*$||' <<< ${POPULATE_RELEASE_FILES})
 
       pop_rel_print_debug "Using File: ${file}"
 
@@ -156,19 +156,26 @@ pop_rel_load_environment() {
   fi
 
   if [[ ${POPULATE_RELEASE_REGISTRY} != "" ]] ; then
-    registry=$(echo ${POPULATE_RELEASE_REGISTRY} | sed -e 's|//*|/|g' -e 's|/*$|/|g')
+    registry=$(sed -e 's|//*|/|g' -e 's|/*$|/|g' <<< ${POPULATE_RELEASE_REGISTRY})
   fi
 
   if [[ ${POPULATE_RELEASE_TAG} != "" ]] ; then
-    tag=$(echo ${POPULATE_RELEASE_TAG} | sed -e 's|/||g')
+    tag=$(sed -e 's|/||g' <<< ${POPULATE_RELEASE_TAG})
   fi
 
   if [[ ${POPULATE_RELEASE_FLOWER} != "" ]] ; then
-    flower=$(echo ${POPULATE_RELEASE_FLOWER} | sed -e 's|/||g')
+    flower=$(sed -e 's|/||g' <<< ${POPULATE_RELEASE_FLOWER})
+  fi
+
+  if [[ $(grep -sho "[/\\\"\']" <<< ${flower}) != "" ]] ; then
+    echo "${p_e}The flower must not contain '/', '\', ''', or '\"' characters: ${flower} ."
+
+    let result=1
+    return
   fi
 
   if [[ ${POPULATE_RELEASE_REPOSITORY} != "" ]] ; then
-    repository=$(echo ${POPULATE_RELEASE_REPOSITORY} | sed -e -e 's|/*$|/|g')
+    repository=$(sed -e -e 's|/*$|/|g' <<< ${POPULATE_RELEASE_REPOSITORY})
   fi
 
   # May be empty, so use "-v" test rather than != "".
@@ -177,7 +184,7 @@ pop_rel_load_environment() {
   fi
 
   if [[ ${part} != "" ]] ; then
-    part="refs/$(echo ${part} | sed -e 's|//*|/|g' -e 's|/*$|/|g')"
+    part="refs/$(sed -e 's|//*|/|g' -e 's|/*$|/|g' <<< ${part})"
   fi
 }
 
@@ -185,7 +192,7 @@ pop_rel_load_source() {
 
   if [[ ${result} -ne 0 ]] ; then return ; fi
 
-  source="$(echo ${repository} | sed -e 's|/*$|/|')${part}${tag}/${file}"
+  source="$(sed -e 's|/*$|/|' <<< ${repository})${part}${tag}/${file}"
 }
 
 pop_rel_print_curl_debug() {
@@ -221,7 +228,6 @@ pop_rel_process_files() {
     pop_rel_load_source
 
     pop_rel_process_files_releases_prepare
-
     pop_rel_process_files_releases_curl
 
     if [[ ${result} -ne 0 ]] ; then break ; fi
@@ -245,12 +251,12 @@ pop_rel_process_files_releases_curl() {
     return
   fi
 
-  source="$(echo ${repository} | sed -e 's|/*$|/|')${part}${tag}/${file}"
+  source="$(sed -e 's|/*$|/|' <<< ${repository})${part}${tag}/${file}"
 
   for release in ${releases} ; do
 
     # Skip any files without the dash in the name used to provide a version.
-    if [[ $(echo ${release} | grep -sho '-') == "" ]] ; then
+    if [[ $(grep -sho '-' <<< ${release}) == "" ]] ; then
       continue
     fi
 
@@ -270,9 +276,9 @@ pop_rel_process_files_releases_curl() {
       echo "Curl requesting Module Descriptor: ${release}."
     fi
 
-    pop_rel_print_curl_debug "Executing Descriptor" "curl -w '\n' ${curl_fail} ${debug_curl_silent} ${debug_curl} ${registry}${release} -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'cache-control: no-cache' -o ${destination}${flower}/${release}"
+    pop_rel_print_curl_debug "Executing Descriptor" "curl -w '\n' ${curl_fail} ${debug_curl_silent} ${debug_curl} '${registry}${release}' -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'cache-control: no-cache' -o '${destination}${flower}/${release}'"
 
-    curl -w '\n' ${curl_fail} ${debug_curl_silent} ${debug_curl} ${registry}${release} -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'cache-control: no-cache' -o ${destination}${flower}/${release}
+    curl -w '\n' ${curl_fail} ${debug_curl_silent} ${debug_curl} "${registry}${release}" -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'cache-control: no-cache' -o "${destination}${flower}/${release}"
 
     pop_rel_handle_result "Curl request failed for: ${registry}${release} to ${destination}${flower}/${release}"
 
@@ -305,7 +311,7 @@ pop_rel_process_files_releases_prepare() {
   fi
 
   if [[ ! -d ${destination}${flower}/ ]] ; then
-    mkdir ${debug} -p ${destination}${flower}/
+    mkdir ${debug} -p "${destination}${flower}/"
 
     pop_rel_handle_result "Create directory failed for destination: ${destination}${flower}/"
   fi
@@ -325,7 +331,6 @@ pop_rel_process_sources() {
     pop_rel_load_source
 
     pop_rel_process_sources_prepare
-
     pop_rel_process_sources_curl
 
     if [[ ${result} -ne 0 ]] ; then break ; fi
@@ -342,7 +347,7 @@ pop_rel_process_sources_prepare() {
   fi
 
   if [[ -e ${file} ]] ; then
-    rm ${debug} -f ${file}
+    rm ${debug} -f "${file}"
 
     pop_rel_handle_result "Create file failed for install file: ${file}"
   fi
@@ -352,9 +357,9 @@ pop_rel_process_sources_curl() {
 
   if [[ ${result} -ne 0 ]] ; then return ; fi
 
-  pop_rel_print_curl_debug "Executing Package" "curl -w '\n' ${curl_fail} ${debug} ${source} -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'cache-control: no-cache' -o ${file}"
+  pop_rel_print_curl_debug "Executing Package" "curl -w '\n' ${curl_fail} ${debug} '${source}' -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'cache-control: no-cache' -o '${file}'"
 
-  curl -w '\n' ${curl_fail} ${debug} ${source} -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'cache-control: no-cache' -o ${file}
+  curl -w '\n' ${curl_fail} ${debug} "${source}" -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'cache-control: no-cache' -o "${file}"
 
   pop_rel_handle_result "Curl request failed for: ${source}"
 }

--- a/script/sync_snapshot.sh
+++ b/script/sync_snapshot.sh
@@ -32,7 +32,7 @@ main() {
 
   local -i result=0
 
-  sync_snap_load_environment
+  sync_snap_load_environment ${*}
 
   sync_snap_determine
 
@@ -53,7 +53,7 @@ main() {
   fi
 
   if [[ ${SYNC_SNAPSHOT_RESULT} != "" ]] ; then
-    echo -n ${updated} > ${SYNC_SNAPSHOT_RESULT}
+    echo -n "${updated}" > "${SYNC_SNAPSHOT_RESULT}"
   fi
 
   return ${result}
@@ -65,7 +65,7 @@ sync_snap_commit() {
 
   sync_snap_print_git_debug "Committing" "git commit -m \"${message}\" ${signoff} ${debug}"
 
-  git commit -m "${message}" ${signoff} ${debug}
+  git commit ${debug} -m "${message}" "${signoff}"
 
   sync_snap_handle_result_git "committing"
 }
@@ -111,14 +111,14 @@ sync_snap_load_environment() {
   if [[ ${SYNC_SNAPSHOT_DEBUG} != "" ]] ; then
     debug="-v"
 
-    if [[ $(echo ${SYNC_SNAPSHOT_DEBUG} | grep -sho "^\s*git\s*$") != "" ]] ; then
+    if [[ $(grep -sho "^\s*git\s*$" <<< ${SYNC_SNAPSHOT_DEBUG}) != "" ]] ; then
       debug_git="y"
-    elif [[ $(echo ${SYNC_SNAPSHOT_DEBUG} | grep -sho "^\s*git_only\s*$") != "" ]] ; then
+    elif [[ $(grep -sho "^\s*git_only\s*$" <<< ${SYNC_SNAPSHOT_DEBUG}) != "" ]] ; then
       debug=
       debug_git="y"
-    elif [[ $(echo ${SYNC_SNAPSHOT_DEBUG} | grep -sho "_only") != "" ]] ; then
+    elif [[ $(grep -sho "_only" <<< ${SYNC_SNAPSHOT_DEBUG}) != "" ]] ; then
       debug=
-    elif [[ $(echo ${SYNC_SNAPSHOT_DEBUG} | grep -sho "\<git\>") != "" ]] ; then
+    elif [[ $(grep -sho "\<git\>" <<< ${SYNC_SNAPSHOT_DEBUG}) != "" ]] ; then
       debug_git="y"
     fi
   fi
@@ -138,7 +138,7 @@ sync_snap_load_environment() {
   fi
 
   if [[ ${path} != "" ]] ; then
-    cd ${path}
+    cd "${path}"
 
     sync_snap_handle_result "Failed to change to path: ${path}"
   fi

--- a/script/sync_snapshot.sh
+++ b/script/sync_snapshot.sh
@@ -65,7 +65,11 @@ sync_snap_commit() {
 
   sync_snap_print_git_debug "Committing" "git commit -m \"${message}\" ${signoff} ${debug}"
 
-  git commit ${debug} -m "${message}" "${signoff}"
+  if [[ ${signoff} == "" ]] ; then
+    git commit -m "${message}" ${debug}
+  else
+    git commit -m "${message}" "${signoff}" ${debug}
+  fi
 
   sync_snap_handle_result_git "committing"
 }

--- a/script/sync_snapshot.sh
+++ b/script/sync_snapshot.sh
@@ -111,14 +111,14 @@ sync_snap_load_environment() {
   if [[ ${SYNC_SNAPSHOT_DEBUG} != "" ]] ; then
     debug="-v"
 
-    if [[ $(grep -sho "^\s*git\s*$" <<< ${SYNC_SNAPSHOT_DEBUG}) != "" ]] ; then
+    if [[ $(grep -sho '^\s*git\s*$' <<< ${SYNC_SNAPSHOT_DEBUG}) != "" ]] ; then
       debug_git="y"
-    elif [[ $(grep -sho "^\s*git_only\s*$" <<< ${SYNC_SNAPSHOT_DEBUG}) != "" ]] ; then
+    elif [[ $(grep -sho '^\s*git_only\s*$' <<< ${SYNC_SNAPSHOT_DEBUG}) != "" ]] ; then
       debug=
       debug_git="y"
-    elif [[ $(grep -sho "_only" <<< ${SYNC_SNAPSHOT_DEBUG}) != "" ]] ; then
+    elif [[ $(grep -sho '_only' <<< ${SYNC_SNAPSHOT_DEBUG}) != "" ]] ; then
       debug=
-    elif [[ $(grep -sho "\<git\>" <<< ${SYNC_SNAPSHOT_DEBUG}) != "" ]] ; then
+    elif [[ $(grep -sho '\<git\>' <<< ${SYNC_SNAPSHOT_DEBUG}) != "" ]] ; then
       debug_git="y"
     fi
   fi


### PR DESCRIPTION
The `BUILD_APP_DESCRIPTOR_RESTRICT_TO` should be allowed to be empty if restriction is not needed.

The variable parameters passed to functions and programs must all be quoted to prevent problems with passing arguments. The variables can expand into multiple arguments due to possible spaces in the variable and can have undesired effects. Only exceptional situations where this behavior is expected and intended are not quoted, such as with `${debug}`. Non-variables are not required to be quoted (should they be for consistency?).

Make sure local variable assignments all have the `=` sign.

Make sure all `*_load_environment` functions pass the arguments (without quotes to expand).

The `pcre_total` should be a number, so use `local -i` instead of `local`.

Check the `flower` variable for invalid characters in all scripts that utilize this variable.

Remove the double quote usage for associative arrays to make the code more consistent. The double quotes can cause problems when nested inside double quotes. Rather than escaping, just remove the quotes entirely given that bash appears to allow this. This helps reduce the chance of mistakes.

Replace all echo pipes, such as `echo "a" | grep -sho "a"`, with the three less than sign pipe, such as `grep -sho "a" <<< "a"`. The `<<<` pipe does not do additional processing and is a little simpler than `echo |`. This also results in the import command being executed to be on the left, thereby making the command being run more obvious.

Wrap file paths in quotes to be on the safe side.
The file paths themselves can have spaces.

Try to keep the `${debug}` and similar parameters as far left in the parameters where possible.